### PR TITLE
refactor: change config file name

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,15 +93,13 @@ inside the `attributes` section like in example below:
 ```
 
 ## Configuration
-To setup amend default plugin configuration we recommend to put following snippet as part of `config/custom.js` or `config/<env>/custom.js` file. If you've got already configurations for other plugins stores by this way, use just the `navigation` part within exising `plugins` item.
+To setup amend default plugin configuration we recommend to put following snippet as part of `config/plugins.js` or `config/<env>/plugins.js` file. If the file does not exist yet, you have to create it manually. If you've got already configurations for other plugins stores by this way, use just the `comments` part within exising `plugins` item.
 
 ```
     ...
-    plugins: {
-      comments: {
-        enableUsers: true,
-        badWords: false
-      },
+    comments: {
+      enableUsers: true,
+      badWords: false
     },
     ...
 ```
@@ -117,22 +115,20 @@ To setup amend default plugin configuration we recommend to put following snippe
 
 ```
     ...
-    plugins: {
-      comments: {
-        enableUsers: true,
-        badWords: false,
-        relatedContentTypes: {
-          pages: {
-            uuid: 'application::pages.pages',
-            contentManager: true,
-            isSingle: true, // optional
-            __contentType: '',
-            key: 'title',
-            value: 'id',
-            url: 'my-custom-url/:id' // optional
-          }
+    comments: {
+      enableUsers: true,
+      badWords: false,
+      relatedContentTypes: {
+        pages: {
+          uuid: 'application::pages.pages',
+          contentManager: true,
+          isSingle: true, // optional
+          __contentType: '',
+          key: 'title',
+          value: 'id',
+          url: 'my-custom-url/:id' // optional
         }
-      },
+      }
     },
     ...
 ```

--- a/services/utils/__tests__/functions.test.js
+++ b/services/utils/__tests__/functions.test.js
@@ -17,11 +17,9 @@ beforeEach(() => {
         }
       },
       config: {
-        custom: {
-          plugins: {
-            comments: {
-              enableUsers: false,
-            }
+        plugins: {
+          comments: {
+            enableUsers: false,
           }
         }
       }
@@ -31,7 +29,7 @@ beforeEach(() => {
 })
 
 describe('Test Comments service functions utils', () => {
-  
+
   describe('Bad Words filtering', () => {
     const text = 'Lorem ipsum dolor sit fuck amet';
 
@@ -55,7 +53,7 @@ describe('Test Comments service functions utils', () => {
     });
 
     test('Should skip bad words filtering because of configuration change', () => {
-      global.strapi.config.custom.plugins.comments.badWords = false;
+      global.strapi.config.plugins.comments.badWords = false;
 
       expect(checkBadWords(text)).toEqual(text);
     });
@@ -74,13 +72,13 @@ describe('Test Comments service functions utils', () => {
 
   describe('Validating user context', () => {
     test('Context should be skipped based on config', () => {
-      global.strapi.config.custom.plugins.comments.enableUsers = false;
+      global.strapi.config.plugins.comments.enableUsers = false;
       expect(isValidUserContext(undefined)).toEqual(true);
       expect(isValidUserContext({ id: 1 })).toEqual(true);
     });
 
     test('Context should be verified based on input', () => {
-      global.strapi.config.custom.plugins.comments.enableUsers = true;
+      global.strapi.config.plugins.comments.enableUsers = true;
       expect(isValidUserContext(undefined)).toEqual(false);
       expect(isValidUserContext({ id: 1 })).toEqual(true);
     });

--- a/services/utils/functions.js
+++ b/services/utils/functions.js
@@ -60,7 +60,7 @@ module.exports = {
     } : item),
 
     checkBadWords: content => {
-        const config = get(strapi.config, 'custom.plugins.comments.badWords', true);
+        const config = get(strapi.config, 'plugins.comments.badWords', true);
         if (config) {
             const filter = new BadWordsFilter(isObject(config) ? config : undefined);
             if (content && filter.isProfane(content)) {
@@ -82,7 +82,7 @@ module.exports = {
     buildNestedStructure,
 
     isValidUserContext: (user = {}) => {
-        const builtInContextEnabled = get(strapi.config, 'custom.plugins.comments.enableUsers', false);
+		const builtInContextEnabled = get(strapi.config, 'plugins.comments.enableUsers', false);
         return builtInContextEnabled ? !isNil(user.id) : true;
     },
 


### PR DESCRIPTION
## Ticket

## Summary

What does this PR do/solve? 

Changes misleading naming of the config file from "custom.js" to "plugins.js". 

## Test Plan

- Install plugin to strapi project.
- Add configuration
- Check if the configuration is being applied