### PR TITLE
Adds missing fields from Comments schema

### DIFF
--- a/config/schema.graphql.js
+++ b/config/schema.graphql.js
@@ -14,6 +14,10 @@ const BASE_COMMENTS = `
   relatedSlug: String
   reports: [CommentReport]
   approvalStatus: CommentApprovalStatus
+  created_at: DateTime!
+  updated_at: DateTime!
+  created_by: ID
+  updated_by: ID
 `;
 
 const configRelatedContentTypes = Object.keys(strapi.config


### PR DESCRIPTION
## Ticket

Fixes https://github.com/VirtusLab/strapi-plugin-comments/issues/85

## Summary

What does this PR do/solve? 

Adds `created_at`, `created_by`, `updated_at` and `updated_by` fields to base Comments schema so they are available to query when fetching comments

## Test Plan

