### PR TITLE
Feat/rest fields query

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,6 +309,7 @@ Return a hierarchical tree structure of comments for specified instance of Conte
 
 #### Strapi REST API properties support:
 
+- [field selection](https://docs.strapi.io/developer-docs/latest/developer-resources/database-apis-reference/rest/populating-fields.html#field-selection)
 - [sorting](https://docs.strapi.io/developer-docs/latest/developer-resources/database-apis-reference/rest/sort-pagination.html#sorting)
 
 ### Get Comments (flat structure)
@@ -350,6 +351,7 @@ Return a flat structure of comments for specified instance of Content Type like 
 #### Strapi REST API properties support:
 
 - [filtering](https://docs.strapi.io/developer-docs/latest/developer-resources/database-apis-reference/rest/filtering-locale-publication.html#filtering)
+- [field selection](https://docs.strapi.io/developer-docs/latest/developer-resources/database-apis-reference/rest/populating-fields.html#field-selection)
 - [sorting](https://docs.strapi.io/developer-docs/latest/developer-resources/database-apis-reference/rest/sort-pagination.html#sorting)
 - [pagination](https://docs.strapi.io/developer-docs/latest/developer-resources/database-apis-reference/rest/sort-pagination.html#pagination)
 

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "rimraf": "^3.0.2",
     "ts-jest": "^27.1.3",
     "ts-node": "^10.7.0",
-    "strapi-typed": "^1.0.7",
+    "strapi-typed": "^1.0.8",
     "typescript": "^4.5.5"
   },
   "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "rimraf": "^3.0.2",
     "ts-jest": "^27.1.3",
     "ts-node": "^10.7.0",
-    "strapi-typed": "^1.0.5",
+    "strapi-typed": "^1.0.7",
     "typescript": "^4.5.5"
   },
   "peerDependencies": {

--- a/server/controllers/client.ts
+++ b/server/controllers/client.ts
@@ -37,6 +37,7 @@ const controllers: IControllerClient = {
     const {
       sort: querySort,
       pagination: queryPagination,
+      fields,
       ...filterQuery
     } = query || {};
 
@@ -48,7 +49,8 @@ const controllers: IControllerClient = {
           relation,
           filterQuery,
           sort || querySort,
-          pagination || queryPagination
+          pagination || queryPagination,
+          fields
         )
       );
     } catch (e: ToBeFixed) {
@@ -63,14 +65,14 @@ const controllers: IControllerClient = {
     const { params, query, sort } = ctx;
     const { relation } = parseParams<{ relation: string }>(params);
 
-    const { sort: querySort, ...filterQuery } = query || {};
+    const { sort: querySort, fields, ...filterQuery } = query || {};
 
     try {
       assertParamsPresent<{ relation: string }>(params, ["relation"]);
 
       return await this.getService<IServiceCommon>("common").findAllInHierarchy(
         {
-          ...flatInput(relation, filterQuery, sort || querySort),
+          ...flatInput<Comment>(relation, filterQuery, sort || querySort, undefined, fields),
           dropBlockedThreads: true,
         }
       );

--- a/server/controllers/client.ts
+++ b/server/controllers/client.ts
@@ -45,13 +45,13 @@ const controllers: IControllerClient = {
       assertParamsPresent<{ relation: string }>(params, ["relation"]);
 
       return this.getService<IServiceCommon>("common").findAllFlat(
-        flatInput(
+        flatInput({
           relation,
-          filterQuery,
-          sort || querySort,
-          pagination || queryPagination,
+          query: filterQuery,
+          sort: sort || querySort,
+          pagination: pagination || queryPagination,
           fields
-        )
+        })
       );
     } catch (e: ToBeFixed) {
       throw throwError(ctx, e);
@@ -72,7 +72,12 @@ const controllers: IControllerClient = {
 
       return await this.getService<IServiceCommon>("common").findAllInHierarchy(
         {
-          ...flatInput<Comment>(relation, filterQuery, sort || querySort, undefined, fields),
+          ...flatInput<Comment>({
+            relation, 
+            query: filterQuery, 
+            sort: sort || querySort, 
+            fields
+          }),
           dropBlockedThreads: true,
         }
       );

--- a/server/controllers/utils/__tests__/parsers.test.js
+++ b/server/controllers/utils/__tests__/parsers.test.js
@@ -5,7 +5,7 @@ jest.mock;
 describe("Test Comments controller parsers utils", () => {
   describe("Flat Input properties", () => {
     const relation = "api::test.relation";
-    const filters = {
+    const query = {
       content: {
         $eq: "Test",
       },
@@ -27,17 +27,20 @@ describe("Test Comments controller parsers utils", () => {
     });
 
     test("Should assign relation to 'query'", () => {
-      expect(flatInput(relation)).toHaveProperty(
+      expect(flatInput({ relation })).toHaveProperty(
         ["query", "related"],
         relation
       );
     });
 
     test("Should assign filters to 'query'", () => {
-      const result = flatInput(relation, filters);
+      const result = flatInput({
+        relation, 
+        query,
+      });
       expect(result).toHaveProperty(
         ["query", "content", "$eq"],
-        filters.content["$eq"]
+        query.content["$eq"]
       );
     });
 
@@ -45,7 +48,10 @@ describe("Test Comments controller parsers utils", () => {
       const overwrittenOrOperator = {
         $or: [{ removed: true }, { removed: false }, { removed: null }],
       };
-      const result = flatInput(relation, overwrittenOrOperator);
+      const result = flatInput({
+        relation, 
+        query: overwrittenOrOperator,
+      });
       expect(result).toHaveProperty(
         ["query", "$or", 0, "removed", "$null"],
         true
@@ -54,12 +60,21 @@ describe("Test Comments controller parsers utils", () => {
     });
 
     test("Should assign sort", () => {
-      const result = flatInput(relation, filters, sort);
+      const result = flatInput({
+        relation, 
+        query, 
+        sort
+      });
       expect(result).toHaveProperty(["sort", "createdAt"], sort.createdAt);
     });
 
     test("Should assign pagination", () => {
-      const result = flatInput(relation, filters, sort, pagination);
+      const result = flatInput({
+        relation, 
+        query,
+        sort,
+        pagination,
+      });
       expect(result).toHaveProperty(["pagination", "page"], pagination.page);
       expect(result).toHaveProperty(
         ["pagination", "pageSize"],
@@ -68,7 +83,12 @@ describe("Test Comments controller parsers utils", () => {
     });
 
     test("Should assign fields", () => {
-      const result = flatInput(relation, filters, sort, undefined, fields);
+      const result = flatInput({
+        relation, 
+        query, 
+        sort, 
+        fields,
+      });
       expect(result).toHaveProperty(["fields", 0], fields[0]);
     });
 
@@ -103,12 +123,12 @@ describe("Test Comments controller parsers utils", () => {
         },
       ];
 
-      const result = flatInput(
+      const result = flatInput({
         relation,
-        complexFilters,
-        complexSort,
-        pagination
-      );
+        query: complexFilters,
+        sort: complexSort,
+        pagination,
+      });
 
       expect(result).toHaveProperty(["query", "related"], relation);
       expect(result).toHaveProperty(

--- a/server/controllers/utils/__tests__/parsers.test.js
+++ b/server/controllers/utils/__tests__/parsers.test.js
@@ -17,6 +17,7 @@ describe("Test Comments controller parsers utils", () => {
       page: 3,
       pageSize: 5,
     };
+    const fields = ["content"];
 
     test("Should contain default property 'populate'", () => {
       expect(flatInput()).toHaveProperty(
@@ -64,6 +65,11 @@ describe("Test Comments controller parsers utils", () => {
         ["pagination", "pageSize"],
         pagination.pageSize
       );
+    });
+
+    test("Should assign fields", () => {
+      const result = flatInput(relation, filters, sort, undefined, fields);
+      expect(result).toHaveProperty(["fields", 0], fields[0]);
     });
 
     test("Should build complex output", () => {

--- a/server/controllers/utils/parsers.ts
+++ b/server/controllers/utils/parsers.ts
@@ -1,13 +1,15 @@
-import { Id, OnlyStrings, StrapiRequestQueryFieldsClause } from "strapi-typed";
-import { ToBeFixed } from "../../../types";
+import { OnlyStrings } from "strapi-typed";
+import { FlatInput, ToBeFixed } from "../../../types";
 
-export const flatInput = <T, TKeys = keyof T>(
-  relation: Id,
-  query: ToBeFixed,
-  sort: ToBeFixed,
-  pagination?: ToBeFixed,
-  fields?: StrapiRequestQueryFieldsClause<OnlyStrings<TKeys>>,
-) => {
+export const flatInput = <T, TKeys = keyof T>(payload: FlatInput<OnlyStrings<TKeys>>) => {
+  const { 
+    relation,
+    query,
+    sort,
+    pagination,
+    fields
+  } = payload;
+
   const filters = query?.filters || query;
   const orOperator = (filters?.$or || []).filter(
     (_: ToBeFixed) => !Object.keys(_).includes("removed")

--- a/server/controllers/utils/parsers.ts
+++ b/server/controllers/utils/parsers.ts
@@ -1,11 +1,12 @@
-import { Id } from "strapi-typed";
+import { Id, OnlyStrings, StrapiRequestQueryFieldsClause } from "strapi-typed";
 import { ToBeFixed } from "../../../types";
 
-export const flatInput = (
+export const flatInput = <T, TKeys = keyof T>(
   relation: Id,
   query: ToBeFixed,
   sort: ToBeFixed,
-  pagination?: ToBeFixed
+  pagination?: ToBeFixed,
+  fields?: StrapiRequestQueryFieldsClause<OnlyStrings<TKeys>>,
 ) => {
   const filters = query?.filters || query;
   const orOperator = (filters?.$or || []).filter(
@@ -24,5 +25,6 @@ export const flatInput = (
     },
     pagination,
     sort,
+    fields,
   };
 };

--- a/server/graphql/queries/findAllFlat.ts
+++ b/server/graphql/queries/findAllFlat.ts
@@ -38,20 +38,20 @@ export = ({ strapi, nexus }: StrapiGraphQLContext) => {
     async resolve(obj: Object, args: ResponseFindAllResolverProps) {
       const { relation, filters, sort, pagination } = args;
       return await getPluginService<IServiceCommon>("common").findAllFlat(
-        flatInput(
+        flatInput({
           relation,
-          getPluginService<IServiceGraphQL>("gql").graphQLFiltersToStrapiQuery(
+          query: getPluginService<IServiceGraphQL>("gql").graphQLFiltersToStrapiQuery(
             filters,
             contentType
           ),
           sort,
-          pagination
+          pagination: pagination
             ? {
                 ...pagination,
                 withCount: !isEmpty(pagination),
               }
             : undefined
-        ),
+            }),
         undefined
       );
     },

--- a/server/graphql/queries/findAllInHierarchy.ts
+++ b/server/graphql/queries/findAllInHierarchy.ts
@@ -33,14 +33,14 @@ export = ({ strapi, nexus }: StrapiGraphQLContext) => {
       return await getPluginService<IServiceCommon>(
         "common"
       ).findAllInHierarchy({
-        ...flatInput(
+        ...flatInput({
           relation,
-          getPluginService<IServiceGraphQL>("gql").graphQLFiltersToStrapiQuery(
+          query: getPluginService<IServiceGraphQL>("gql").graphQLFiltersToStrapiQuery(
             filters,
             contentType
           ),
-          sort
-        ),
+          sort,
+        }),
         dropBlockedThreads: true,
       });
     },

--- a/server/graphql/queries/findAllInHierarchy.ts
+++ b/server/graphql/queries/findAllInHierarchy.ts
@@ -14,7 +14,6 @@ type findAllInHierarchyProps = {
   relation: Id;
   filters: ToBeFixed;
   sort: ToBeFixed;
-  pagination: ToBeFixed;
 };
 
 export = ({ strapi, nexus }: StrapiGraphQLContext) => {

--- a/server/services/__tests__/common.test.ts
+++ b/server/services/__tests__/common.test.ts
@@ -13,6 +13,16 @@ const setup = (config = {}, toStore = false, database = {}) => {
   });
 };
 
+const filterOutUndefined = (_: any) => Object.keys(_).reduce((prev, curr) => {
+  if (_[curr] !== undefined) {
+    return {
+      ...prev,
+      [curr]: _[curr],
+    }
+  }
+  return prev;
+}, {});
+
 afterEach(() => {
   Object.defineProperty(global, "strapi", {});
 });
@@ -410,6 +420,19 @@ describe("Test Comments service functions utils", () => {
           expect(result.data.length).toBe(4);
           expect(result).toHaveProperty(["data", 0, "content"], db[0].content);
           expect(result).toHaveProperty(["data", 3, "content"], db[3].content);
+        });
+
+        test("Should return structure with selected fields only (+mandatory ones for logic)", async () => { // Default fields are: id, related, threadOf, gotThread
+          const result = await getPluginService<IServiceCommon>(
+            "common"
+          ).findAllFlat({ query: { related }, fields: ['content'] }, relatedEntity);
+          expect(result).toHaveProperty("data");
+          expect(result).not.toHaveProperty("meta");
+          expect(result.data.length).toBe(4);
+          expect(Object.keys(filterOutUndefined(result.data[0]))).toHaveLength(6);
+          expect(Object.keys(filterOutUndefined(result.data[1]))).toHaveLength(6);
+          expect(Object.keys(filterOutUndefined(result.data[2]))).toHaveLength(6);
+          expect(Object.keys(filterOutUndefined(result.data[3]))).toHaveLength(6);
         });
 
         test("Should return structure with pagination", async () => {

--- a/server/services/admin.ts
+++ b/server/services/admin.ts
@@ -140,7 +140,7 @@ export = ({ strapi }: StrapiContext): IServiceAdmin => ({
       $or: [{ removed: false }, { removed: null }],
     };
 
-    let params: StrapiDBQueryArgs = {
+    let params: StrapiDBQueryArgs<keyof Comment> = {
       where: !isEmpty(filters)
         ? {
             ...defaultWhere,
@@ -177,7 +177,7 @@ export = ({ strapi }: StrapiContext): IServiceAdmin => ({
           },
         },
       });
-    const total = await strapi.db.query<number>(getModelUid("comment")).count({
+    const total = await strapi.db.query<Comment>(getModelUid("comment")).count({
       where: params.where,
     });
     const relatedEntities =

--- a/types/contentTypes.ts
+++ b/types/contentTypes.ts
@@ -40,6 +40,7 @@ export type CommentAuthorPartial = {
 
 export type CommentReport = {
   id: Id;
+  related: Comment | Id;
   reason: any;
   content: string;
   resolved: boolean;

--- a/types/controllers.d.ts
+++ b/types/controllers.d.ts
@@ -11,6 +11,8 @@ import {
   StrapiQueryParamsParsedFilters,
   StrapiQueryParamsParsedOrderBy,
   StrapiUser,
+  StrapiRequestQueryFieldsClause,
+  OnlyStrings,
 } from "strapi-typed";
 import { ToBeFixed } from "./common";
 import {
@@ -33,6 +35,14 @@ import {
   AdminSinglePageResponse,
   CommentsPluginServices,
 } from "./services";
+
+export type FlatInput<TKeys extends string> = {
+  relation: Id,
+  query: ToBeFixed,
+  sort: ToBeFixed,
+  pagination?: ToBeFixed,
+  fields?: StrapiRequestQueryFieldsClause<TKeys>,
+}
 
 export type ThrowableResponse<T> = T | PluginError | never;
 export type ThrowablePromisedResponse<T> = Promise<ThrowableResponse<T>>;

--- a/types/controllers.d.ts
+++ b/types/controllers.d.ts
@@ -65,7 +65,7 @@ export interface IControllerAdmin {
     ctx: StrapiRequestContext
   ): ThrowablePromisedResponse<SettingsCommentsPluginConfig>;
   settingsUpdateConfig(
-    ctx: StrapiRequestContext
+    ctx: StrapiRequestContext<SettingsCommentsPluginConfig>
   ): ThrowablePromisedResponse<SettingsCommentsPluginConfig>;
   settingsRestoreConfig(
     ctx: StrapiRequestContext<SettingsCommentsPluginConfig>

--- a/types/services.d.ts
+++ b/types/services.d.ts
@@ -34,8 +34,8 @@ export type FindAllFlatProps<T, TFields = keyof T> = {
     threadOf?: number | string | null;
     [key: string]: any;
   } & {};
-  populate?: StringMap<any>;
-  sort?: StringMap<any>;
+  populate?: StringMap<unknown>;
+  sort?: StringMap<unknown>;
   fields?: StrapiRequestQueryFieldsClause<OnlyStrings<TFields>>
   pagination?: StrapiPagination;
 };

--- a/types/services.d.ts
+++ b/types/services.d.ts
@@ -10,6 +10,9 @@ import {
   StrapiQueryParamsParsedFilters,
   StrapiQueryParamsParsedOrderBy,
   StrapiUser,
+  OnlyStrings,
+  StringMap,
+  StrapiRequestQueryFieldsClause,
 } from "strapi-typed";
 import { ToBeFixed } from "./common";
 import {
@@ -26,17 +29,14 @@ export type AdminPaginatedResponse<T> = {
   result: Array<T>;
 } & StrapiResponseMeta;
 
-export type FindAllFlatProps = {
+export type FindAllFlatProps<T, TFields = keyof T> = {
   query: {
     threadOf?: number | string | null;
     [key: string]: any;
   } & {};
-  populate?: {
-    [key: string]: any;
-  };
-  sort?: {
-    [key: string]: any;
-  };
+  populate?: StringMap<any>;
+  sort?: StringMap<any>;
+  fields?: StrapiRequestQueryFieldsClause<OnlyStrings<TFields>>
   pagination?: StrapiPagination;
 };
 
@@ -74,7 +74,7 @@ export interface IServiceCommon {
   getPluginStore(): Promise<StrapiStore>;
   getLocalConfig<T>(path?: string, defaultValue?: any): T;
   findAllFlat(
-    props: FindAllFlatProps,
+    props: FindAllFlatProps<Comment>,
     relatedEntity?: RelatedEntity | null | boolean
   ): Promise<StrapiPaginatedResponse<Comment>>;
   findAllInHierarchy(

--- a/yarn.lock
+++ b/yarn.lock
@@ -793,10 +793,46 @@
     pluralize "^8.0.0"
     subscriptions-transport-ws "0.9.19"
 
+"@strapi/plugin-graphql@^4.1.8":
+  version "4.1.8"
+  resolved "https://registry.yarnpkg.com/@strapi/plugin-graphql/-/plugin-graphql-4.1.8.tgz#7c3c9698bd191cfed130ddc9f2024ea936228a0e"
+  integrity sha512-Y5GC2YUU1gCGa392GxH5jvN1YgGoPt5biZpCfBe2u2O/UWB1O+kDZy+OgK6aydN9kI8HFTwxWiaipcunNDYmCw==
+  dependencies:
+    "@apollo/federation" "^0.28.0"
+    "@graphql-tools/schema" "8.1.2"
+    "@graphql-tools/utils" "^8.0.2"
+    "@strapi/utils" "4.1.8"
+    apollo-server-core "3.1.2"
+    apollo-server-koa "3.1.2"
+    glob "^7.1.7"
+    graphql "^15.5.1"
+    graphql-depth-limit "^1.1.0"
+    graphql-iso-date "^3.6.1"
+    graphql-playground-middleware-koa "^1.6.21"
+    graphql-type-json "^0.3.2"
+    graphql-type-long "^0.1.1"
+    graphql-upload "^13.0.0"
+    koa-compose "^4.1.0"
+    lodash "4.17.21"
+    nexus "1.2.0"
+    pluralize "^8.0.0"
+    subscriptions-transport-ws "0.9.19"
+
 "@strapi/utils@4.1.6", "@strapi/utils@^4.1.6":
   version "4.1.6"
   resolved "https://registry.yarnpkg.com/@strapi/utils/-/utils-4.1.6.tgz#edfdec2470143b2437cc95a5119ef5fa7d892eb4"
   integrity sha512-QVuxGKHw9uh72CwtpKJTPz5ECgFBbtydvUjY34PCZMPkJ0EQ7/spz3KZbB+v2JSPgy1apZJn5qkBGFcvSvBxRw==
+  dependencies:
+    "@sindresorhus/slugify" "1.1.0"
+    date-fns "2.24.0"
+    http-errors "1.8.0"
+    lodash "4.17.21"
+    yup "0.32.9"
+
+"@strapi/utils@4.1.8", "@strapi/utils@^4.1.8":
+  version "4.1.8"
+  resolved "https://registry.yarnpkg.com/@strapi/utils/-/utils-4.1.8.tgz#22c5b10b145f0ce005aefdb5611552ac73d02b23"
+  integrity sha512-FMC9gNQ+cXQNRkOaIiom6NlMIqqzo1gA9W/MkR/qezKIsivp+2nC+RsY4amS70D58yU/kjr1BdN5FtnwuyzOLQ==
   dependencies:
     "@sindresorhus/slugify" "1.1.0"
     date-fns "2.24.0"
@@ -3369,7 +3405,7 @@ minimatch@^3.0.4:
   dependencies:
     brace-expansion "^1.1.7"
 
-minimist@^1.1.1, minimist@^1.2.0, minimist@^1.2.5:
+minimist@^1.2.0, minimist@^1.2.5:
   version "1.2.6"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.6.tgz#8637a5b759ea0d6e98702cfb3a9283323c93af44"
   integrity sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==
@@ -3987,10 +4023,10 @@ stack-utils@^2.0.3:
   resolved "https://registry.yarnpkg.com/statuses/-/statuses-1.5.0.tgz#161c7dac177659fd9811f43771fa99381478628c"
   integrity sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=
 
-strapi-typed@^1.0.5:
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/strapi-typed/-/strapi-typed-1.0.5.tgz#2bf0574c767058ec0fc85c2d32c8d45d0910942d"
-  integrity sha512-00K1pnyCfT3Oe/Z4jjJrWDd02c43NWaTHdngVUIKHOEDiroQBOHz/MsFRrVOf5x7HF/rgGhNsCcq4n89HoNLig==
+strapi-typed@^1.0.7:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/strapi-typed/-/strapi-typed-1.0.7.tgz#6f7a9bc5619138a842f456d7fb7db7854ca5f2d5"
+  integrity sha512-g6mpK1GSwpse6rOJ6bCdpQYdL1glHrSxtFjn+drdeZL3k5jEsIzp+MXDGomeAo04mP7KycJ3l+j+ZM0r/ob2LQ==
   dependencies:
     "@strapi/plugin-graphql" "^4.1.6"
     "@strapi/utils" "^4.1.6"

--- a/yarn.lock
+++ b/yarn.lock
@@ -768,31 +768,6 @@
   dependencies:
     "@sinonjs/commons" "^1.7.0"
 
-"@strapi/plugin-graphql@^4.1.6":
-  version "4.1.6"
-  resolved "https://registry.yarnpkg.com/@strapi/plugin-graphql/-/plugin-graphql-4.1.6.tgz#c5c5c5fe5581a953803142c6836a12a4f0e1207c"
-  integrity sha512-TiGFbX6HdTHikWi4sPwiNZih6HOVLh1Y6wmEfjpxTsm4pYog9KE78Jr7SIIIcXaXrfZAHdT0xAOaB9W8assN7w==
-  dependencies:
-    "@apollo/federation" "^0.28.0"
-    "@graphql-tools/schema" "8.1.2"
-    "@graphql-tools/utils" "^8.0.2"
-    "@strapi/utils" "4.1.6"
-    apollo-server-core "3.1.2"
-    apollo-server-koa "3.1.2"
-    glob "^7.1.7"
-    graphql "^15.5.1"
-    graphql-depth-limit "^1.1.0"
-    graphql-iso-date "^3.6.1"
-    graphql-playground-middleware-koa "^1.6.21"
-    graphql-type-json "^0.3.2"
-    graphql-type-long "^0.1.1"
-    graphql-upload "^13.0.0"
-    koa-compose "^4.1.0"
-    lodash "4.17.21"
-    nexus "1.2.0"
-    pluralize "^8.0.0"
-    subscriptions-transport-ws "0.9.19"
-
 "@strapi/plugin-graphql@^4.1.8":
   version "4.1.8"
   resolved "https://registry.yarnpkg.com/@strapi/plugin-graphql/-/plugin-graphql-4.1.8.tgz#7c3c9698bd191cfed130ddc9f2024ea936228a0e"
@@ -817,17 +792,6 @@
     nexus "1.2.0"
     pluralize "^8.0.0"
     subscriptions-transport-ws "0.9.19"
-
-"@strapi/utils@4.1.6", "@strapi/utils@^4.1.6":
-  version "4.1.6"
-  resolved "https://registry.yarnpkg.com/@strapi/utils/-/utils-4.1.6.tgz#edfdec2470143b2437cc95a5119ef5fa7d892eb4"
-  integrity sha512-QVuxGKHw9uh72CwtpKJTPz5ECgFBbtydvUjY34PCZMPkJ0EQ7/spz3KZbB+v2JSPgy1apZJn5qkBGFcvSvBxRw==
-  dependencies:
-    "@sindresorhus/slugify" "1.1.0"
-    date-fns "2.24.0"
-    http-errors "1.8.0"
-    lodash "4.17.21"
-    yup "0.32.9"
 
 "@strapi/utils@4.1.8", "@strapi/utils@^4.1.8":
   version "4.1.8"
@@ -4023,13 +3987,13 @@ stack-utils@^2.0.3:
   resolved "https://registry.yarnpkg.com/statuses/-/statuses-1.5.0.tgz#161c7dac177659fd9811f43771fa99381478628c"
   integrity sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=
 
-strapi-typed@^1.0.7:
-  version "1.0.7"
-  resolved "https://registry.yarnpkg.com/strapi-typed/-/strapi-typed-1.0.7.tgz#6f7a9bc5619138a842f456d7fb7db7854ca5f2d5"
-  integrity sha512-g6mpK1GSwpse6rOJ6bCdpQYdL1glHrSxtFjn+drdeZL3k5jEsIzp+MXDGomeAo04mP7KycJ3l+j+ZM0r/ob2LQ==
+strapi-typed@^1.0.8:
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/strapi-typed/-/strapi-typed-1.0.8.tgz#2dc48b5dc0022fd25a72be5f59ae990e3676d765"
+  integrity sha512-ncJ6/+wKjIqUG9SHOvxUvLQ2WwwpkMd5YWLzqukkDKTfbRZ0zZRWl95APZemD40VHq5rKCGZAkpvUllITcJ0bw==
   dependencies:
-    "@strapi/plugin-graphql" "^4.1.6"
-    "@strapi/utils" "^4.1.6"
+    "@strapi/plugin-graphql" "^4.1.8"
+    "@strapi/utils" "^4.1.8"
 
 stream-events@^1.0.5:
   version "1.0.5"


### PR DESCRIPTION
## Ticket

https://github.com/VirtusLab/strapi-plugin-comments/issues/115

## Summary

What does this PR do/solve? 

Introduce support of `Fields` query via `REST API` according to Strapi documentation:

https://docs.strapi.io/developer-docs/latest/developer-resources/database-apis-reference/rest/populating-fields.html#field-selection

## Test Plan

How are you testing the work you're submitting?

1. Run project
2. Try to call API with `?fields[0]=content` and see that there are present some mandatory fields like `id, related, threadOf, gotThread` and `content`. Other fields has been dropped. Works for both `flat` and `hierarchical` query

> Note
> This is not supported by GraphQL by design, not necessary.
