### PR TITLE
[CU-2cq60k0] feat: issue #113 author field population

### DIFF
--- a/__mocks__/initSetup.ts
+++ b/__mocks__/initSetup.ts
@@ -22,7 +22,7 @@ export = (config: any = {}, toStore: boolean = false, database: any = {}) => {
         const parseValues = (values: any[], args: any = {}) => values.map(_ => {
           const { select = [] } = args;
           if (!isEmpty(select)) {
-            return pick(_, [...select, 'threadOf', 'authorUser']); // Relation fields can't be "unselected"
+            return pick(_, [...select, 'threadOf']);
           }
           return _;
         })

--- a/admin/src/components/Avatar/index.tsx
+++ b/admin/src/components/Avatar/index.tsx
@@ -1,0 +1,34 @@
+/**
+ *
+ * Avatar
+ *
+ */
+
+// @ts-nocheck
+
+import React from "react";
+import PropTypes from "prop-types";
+import { isObject } from "lodash";
+import { Avatar, Initials } from "@strapi/design-system/Avatar";
+import { renderInitials } from "../../utils";
+
+const UserAvatar = ({
+  avatar,
+  name,
+}) => {
+  if (avatar) {
+    let image = avatar;
+    if (isObject(avatar)) {
+      image = avatar?.formats?.thumbnail.url || avatar.url
+    }
+    return <Avatar src={image} alt={name} />
+  }
+  return <Initials>{renderInitials(name)}</Initials>
+};
+
+UserAvatar.propTypes = {
+  avatar: PropTypes.oneOfType(PropTypes.string, PropTypes.object).isRequired,
+  name: PropTypes.string,
+};
+
+export default UserAvatar;

--- a/admin/src/components/DiscussionThreadItemFooter/index.tsx
+++ b/admin/src/components/DiscussionThreadItemFooter/index.tsx
@@ -9,14 +9,13 @@
 import React from "react";
 import PropTypes from "prop-types";
 import { useIntl } from "react-intl";
-import { Avatar, Initials } from "@strapi/design-system/Avatar";
 import { Box } from "@strapi/design-system/Box";
 import { Typography } from "@strapi/design-system/Typography";
-import { renderInitials } from "../../utils";
 import {
   DiscussionThreadItemFooterMeta,
   DiscussionThreadItemFooterStyled,
 } from "./styles";
+import UserAvatar from "../Avatar";
 
 const DiscussionThreadItemFooter = ({
   children,
@@ -35,11 +34,7 @@ const DiscussionThreadItemFooter = ({
   return (
     <DiscussionThreadItemFooterStyled as={Box} paddingTop={2} direction="row">
       <DiscussionThreadItemFooterMeta size={3} horizontal>
-        {avatar ? (
-          <Avatar src={avatar} alt={name} />
-        ) : (
-          <Initials>{renderInitials(name)}</Initials>
-        )}
+        <UserAvatar avatar={avatar} name={name} />
         <Typography variant="pi" fontWeight="bold" textColor="neutral800">
           {name}
         </Typography>
@@ -57,7 +52,7 @@ DiscussionThreadItemFooter.propTypes = {
     id: PropTypes.oneOfType(PropTypes.string, PropTypes.number).isRequired,
     name: PropTypes.string.isRequired,
     email: PropTypes.string,
-    avatar: PropTypes.string,
+    avatar: PropTypes.oneOfType(PropTypes.string, PropTypes.object),
   }).isRequired,
   createdAt: PropTypes.string.isRequired,
   updatedAt: PropTypes.string,

--- a/admin/src/pages/Discover/components/DiscoverTableRow/index.tsx
+++ b/admin/src/pages/Discover/components/DiscoverTableRow/index.tsx
@@ -5,7 +5,6 @@ import PropTypes from "prop-types";
 import { useIntl } from "react-intl";
 import { useMutation, useQueryClient } from "react-query";
 import { isNil, isEmpty } from "lodash";
-import { Avatar, Initials } from "@strapi/design-system/Avatar";
 import { Flex } from "@strapi/design-system/Flex";
 import { IconButton } from "@strapi/design-system/IconButton";
 import { Link } from "@strapi/design-system/Link";
@@ -18,7 +17,6 @@ import {
   getMessage,
   getUrl,
   handleAPIError,
-  renderInitials,
   resolveCommentStatus,
   resolveCommentStatusColor,
 } from "../../../../utils";
@@ -31,6 +29,7 @@ import DiscussionThreadItemApprovalFlowActions from "../../../../components/Disc
 import StatusBadge from "../../../../components/StatusBadge";
 import { IconButtonGroupStyled } from "../../../../components/IconButton/styles";
 import DiscussionThreadItemReviewAction from "../../../../components/DiscussionThreadItemReviewAction";
+import UserAvatar from "../../../../components/Avatar";
 
 const DiscoverTableRow = ({
   config,
@@ -154,11 +153,7 @@ const DiscoverTableRow = ({
       </Td>
       <Td>
         <Stack size={2} horizontal>
-          {item.author?.avatar ? (
-            <Avatar src={item.author?.avatar} alt={item.author.name} />
-          ) : (
-            <Initials>{renderInitials(item.author.name)}</Initials>
-          )}
+          <UserAvatar avatar={item.author?.avatar} name={item.author.name} />
           <Typography textColor="neutral800" variant="pi">
             {item.author.name}
           </Typography>

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "ts-jest": "^27.1.3",
     "ts-node": "^10.7.0",
     "strapi-typed": "^1.0.8",
-    "typescript": "^4.5.5"
+    "typescript": "^4.6.3"
   },
   "peerDependencies": {
     "@strapi/strapi": "4.x"

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "rimraf": "^3.0.2",
     "ts-jest": "^27.1.3",
     "ts-node": "^10.7.0",
-    "strapi-typed": "^1.0.8",
+    "strapi-typed": "^1.0.9",
     "typescript": "^4.6.3"
   },
   "peerDependencies": {

--- a/server/services/__tests__/common.test.ts
+++ b/server/services/__tests__/common.test.ts
@@ -393,9 +393,15 @@ describe("Test Comments service functions utils", () => {
           content: "IKL",
           threadOf: 2,
           related,
-          authorId: 1,
-          authorName: "Joe Doe",
-          authorEmail: "joe@example.com",
+          authorUser: {
+            id: 1,
+            username: "Joe Doe",
+            email: "joe@example.com",
+            avatar: {
+              id: 1,
+              url: 'http://example.com'
+            }
+          }
         },
       ];
       const relatedEntity = { id: 1, title: "Test", uid: collection };
@@ -433,6 +439,23 @@ describe("Test Comments service functions utils", () => {
           expect(Object.keys(filterOutUndefined(result.data[1]))).toHaveLength(6);
           expect(Object.keys(filterOutUndefined(result.data[2]))).toHaveLength(6);
           expect(Object.keys(filterOutUndefined(result.data[3]))).toHaveLength(6);
+        });
+
+        test("Should return structure with populated avatar field", async () => {
+          const result = await getPluginService<IServiceCommon>(
+            "common"
+          ).findAllFlat({ 
+            query: { related },
+            populate: { 
+              authorUser: { 
+                populate: { avatar: true },
+              },
+            }
+          }, relatedEntity);
+          expect(result).toHaveProperty("data");
+          expect(result).not.toHaveProperty("meta");
+          expect(result.data.length).toBe(4);
+          expect(result).toHaveProperty(["data", 3, "author", "avatar", "url"], db[3].authorUser.avatar.url);
         });
 
         test("Should return structure with pagination", async () => {

--- a/server/services/admin.ts
+++ b/server/services/admin.ts
@@ -7,6 +7,7 @@ import {
   AdminSinglePageResponse,
   AnyConfig,
   Comment,
+  CommentModelKeys,
   CommentReport,
   IServiceAdmin,
   IServiceCommon,
@@ -24,6 +25,8 @@ import {
   filterOurResolvedReports,
 } from "./utils/functions";
 import { APPROVAL_STATUS, REGEX } from "./../utils/constants";
+
+const DEFAULT_AUTHOR_POPULATE = { avatar: true };
 
 /**
  * Comments Plugin - Moderation services
@@ -140,7 +143,7 @@ export = ({ strapi }: StrapiContext): IServiceAdmin => ({
       $or: [{ removed: false }, { removed: null }],
     };
 
-    let params: StrapiDBQueryArgs<keyof Comment> = {
+    let params: StrapiDBQueryArgs<CommentModelKeys> = {
       where: !isEmpty(filters)
         ? {
             ...defaultWhere,
@@ -168,7 +171,7 @@ export = ({ strapi }: StrapiContext): IServiceAdmin => ({
       .findMany({
         ...params,
         populate: {
-          authorUser: { populate: { avatar: true } },
+          authorUser: { populate: DEFAULT_AUTHOR_POPULATE },
           threadOf: true,
           reports: {
             where: {
@@ -185,7 +188,7 @@ export = ({ strapi }: StrapiContext): IServiceAdmin => ({
     const result = entities
       .map((_) =>
         filterOurResolvedReports(
-          this.getCommonService().sanitizeCommentEntity(_, { avatar: true })
+          this.getCommonService().sanitizeCommentEntity(_, DEFAULT_AUTHOR_POPULATE)
         )
       )
       .map((_) =>
@@ -227,12 +230,12 @@ export = ({ strapi }: StrapiContext): IServiceAdmin => ({
     const defaultPopulate = {
       populate: {
         authorUser: {
-          populate: { avatar: true }
+          populate: DEFAULT_AUTHOR_POPULATE,
         },
         threadOf: {
           populate: {
             authorUser: {
-              populate: { avatar: true }
+              populate: DEFAULT_AUTHOR_POPULATE,
             },
             ...reportsPopulation,
           },
@@ -292,7 +295,7 @@ export = ({ strapi }: StrapiContext): IServiceAdmin => ({
     const selectedEntity = this.getCommonService().sanitizeCommentEntity({
       ...entity,
       threadOf: entity.threadOf || null,
-    }, { avatar: true });
+    }, DEFAULT_AUTHOR_POPULATE);
 
     return {
       entity: relatedEntity,

--- a/server/services/admin.ts
+++ b/server/services/admin.ts
@@ -168,7 +168,7 @@ export = ({ strapi }: StrapiContext): IServiceAdmin => ({
       .findMany({
         ...params,
         populate: {
-          authorUser: true,
+          authorUser: { populate: { avatar: true } },
           threadOf: true,
           reports: {
             where: {
@@ -185,7 +185,7 @@ export = ({ strapi }: StrapiContext): IServiceAdmin => ({
     const result = entities
       .map((_) =>
         filterOurResolvedReports(
-          this.getCommonService().sanitizeCommentEntity(_)
+          this.getCommonService().sanitizeCommentEntity(_, { avatar: true })
         )
       )
       .map((_) =>
@@ -226,10 +226,14 @@ export = ({ strapi }: StrapiContext): IServiceAdmin => ({
 
     const defaultPopulate = {
       populate: {
-        authorUser: true,
+        authorUser: {
+          populate: { avatar: true }
+        },
         threadOf: {
           populate: {
-            authorUser: true,
+            authorUser: {
+              populate: { avatar: true }
+            },
             ...reportsPopulation,
           },
         },
@@ -288,7 +292,7 @@ export = ({ strapi }: StrapiContext): IServiceAdmin => ({
     const selectedEntity = this.getCommonService().sanitizeCommentEntity({
       ...entity,
       threadOf: entity.threadOf || null,
-    });
+    }, { avatar: true });
 
     return {
       entity: relatedEntity,

--- a/server/services/client.ts
+++ b/server/services/client.ts
@@ -35,7 +35,7 @@ export = ({ strapi }: StrapiContext): IServiceClient => ({
     this: IServiceClient,
     relation: string,
     data: CreateCommentPayload,
-    user: StrapiUser = undefined
+    user: StrapiUser
   ): Promise<Comment> {
     const { content, threadOf } = data;
     const singleRelationFulfilled = relation && REGEX.relatedUid.test(relation);
@@ -156,7 +156,7 @@ export = ({ strapi }: StrapiContext): IServiceClient => ({
     id: Id,
     relation: string,
     data: UpdateCommentPayload,
-    user: StrapiUser = undefined
+    user: StrapiUser
   ): Promise<Comment> {
     const { content } = data;
 
@@ -206,7 +206,7 @@ export = ({ strapi }: StrapiContext): IServiceClient => ({
     id: Id,
     relation: string,
     payload: CreateCommentReportPayload,
-    user: StrapiUser = undefined
+    user: StrapiUser
   ): Promise<CommentReport> {
     if (!this.getCommonService().isValidUserContext(user)) {
       throw resolveUserContextError(user);
@@ -254,7 +254,7 @@ export = ({ strapi }: StrapiContext): IServiceClient => ({
     id: Id,
     relation: string,
     authorId: Id,
-    user: StrapiUser = undefined
+    user: StrapiUser
   ): Promise<Comment> {
     if (!this.getCommonService().isValidUserContext(user)) {
       throw resolveUserContextError(user);

--- a/server/services/common.ts
+++ b/server/services/common.ts
@@ -20,6 +20,7 @@ import {
   StrapiResponseMeta,
   StrapiPaginatedResponse,
   StrapiDBQueryArgs,
+  StringMap,
 } from "strapi-typed";
 import {
   CommentsPluginConfig,
@@ -240,7 +241,7 @@ export = ({ strapi }: StrapiContext): IServiceCommon => ({
         threadOf: parsedThreadOf || _.threadOf || null,
         gotThread: (threadedItem?.itemsInTread || 0) > 0,
         threadFirstItemId: threadedItem?.firstThreadItemId,
-      });
+      }, populate?.authorUser?.populate);
     });
 
     return {
@@ -386,14 +387,16 @@ export = ({ strapi }: StrapiContext): IServiceCommon => ({
     }
   },
 
-  sanitizeCommentEntity(entity: Comment): Comment {
+  sanitizeCommentEntity(entity: Comment, populate?: StringMap<boolean | Array<string> | StringMap<unknown>>): Comment {
+    const fieldsToPopulate = isArray(populate) ? populate : Object.keys(populate || {});
+
     return {
       ...buildAuthorModel({
         ...entity,
         threadOf: isObject(entity.threadOf)
-          ? buildAuthorModel(entity.threadOf)
+          ? buildAuthorModel(entity.threadOf, fieldsToPopulate)
           : entity.threadOf,
-      }),
+      }, fieldsToPopulate),
     };
   },
 

--- a/server/services/utils/functions.ts
+++ b/server/services/utils/functions.ts
@@ -94,7 +94,7 @@ export const convertContentTypeNameToSlug = (str: string): string => {
     : plainConversion;
 };
 
-export const buildAuthorModel = (item: Comment): Comment => {
+export const buildAuthorModel = (item: Comment, fieldsToPopulate: Array<string> = []): Comment => {
   const {
     authorUser,
     authorId,
@@ -105,12 +105,16 @@ export const buildAuthorModel = (item: Comment): Comment => {
   } = item;
   let author: CommentAuthor = {} as CommentAuthor;
   if (authorUser) {
-    author = {
-      id: authorUser.id,
-      name: authorUser.username,
-      email: authorUser.email,
-      avatar: authorUser.avatar,
-    };
+    author = fieldsToPopulate
+      .reduce((prev, curr) => ({
+        ...prev,
+        [curr]: authorUser[curr],
+      }), {
+        id: authorUser.id,
+        name: authorUser.username,
+        email: authorUser.email,
+        avatar: authorUser.avatar,
+      });
   } else if (authorId) {
     author = {
       id: authorId,

--- a/types/contentTypes.ts
+++ b/types/contentTypes.ts
@@ -1,11 +1,11 @@
-import { StrapiUser } from "strapi-typed";
+import { StrapiUser, StringMap } from "strapi-typed";
 
 export type Id = number | string;
 
-export type Comment = {
+export type Comment<TAuthor = CommentAuthor> = {
   id: Id;
   content: string;
-  author?: CommentAuthor | undefined;
+  author?: TAuthor | undefined;
   children?: Array<Comment>;
   reports?: Array<CommentReport>;
   threadOf: Comment | number | null;
@@ -37,6 +37,8 @@ export type CommentAuthorPartial = {
   authorAvatar?: string;
   authorUser?: StrapiUser;
 };
+
+export type CommentAuthorResolved = CommentAuthor & StringMap<unknown>;
 
 export type CommentReport = {
   id: Id;

--- a/types/contentTypes.ts
+++ b/types/contentTypes.ts
@@ -1,11 +1,11 @@
-import { StrapiUser, StringMap } from "strapi-typed";
+import { OnlyStrings, StrapiUser, StringMap } from "strapi-typed";
 
 export type Id = number | string;
 
 export type Comment<TAuthor = CommentAuthor> = {
   id: Id;
   content: string;
-  author?: TAuthor | undefined;
+  author?: TAuthor;
   children?: Array<Comment>;
   reports?: Array<CommentReport>;
   threadOf: Comment | number | null;
@@ -19,7 +19,7 @@ export type Comment<TAuthor = CommentAuthor> = {
   threadFirstItemId?: Id;
 } & CommentAuthorPartial;
 
-export type CommentModelKeys = keyof Comment;
+export type CommentModelKeys = OnlyStrings<keyof Comment>;
 
 type CommentApprovalStatus = "PENDING" | "APPROVED" | "REJECTED";
 
@@ -38,7 +38,7 @@ export type CommentAuthorPartial = {
   authorUser?: StrapiUser;
 };
 
-export type CommentAuthorResolved = CommentAuthor & StringMap<unknown>;
+export type CommentAuthorResolved<TExtension = StringMap<unknown>> = CommentAuthor & TExtension;
 
 export type CommentReport = {
   id: Id;

--- a/types/services.d.ts
+++ b/types/services.d.ts
@@ -92,7 +92,7 @@ export interface IServiceCommon {
     fieldName: string,
     value: any
   ): Promise<boolean>;
-  sanitizeCommentEntity(entity: Comment): Comment;
+  sanitizeCommentEntity(entity: Comment, populate?: StringMap<boolean | Array<string> | StringMap<unknown>>): Comment;
   isValidUserContext(user?: any): boolean;
   parseRelationString(
     relation: string

--- a/types/services.d.ts
+++ b/types/services.d.ts
@@ -13,6 +13,7 @@ import {
   OnlyStrings,
   StringMap,
   StrapiRequestQueryFieldsClause,
+  PopulateClause,
 } from "strapi-typed";
 import { ToBeFixed } from "./common";
 import {
@@ -34,7 +35,7 @@ export type FindAllFlatProps<T, TFields = keyof T> = {
     threadOf?: number | string | null;
     [key: string]: any;
   } & {};
-  populate?: StringMap<unknown>;
+  populate?: PopulateClause<OnlyStrings<TFields>>;
   sort?: StringMap<unknown>;
   fields?: StrapiRequestQueryFieldsClause<OnlyStrings<TFields>>
   pagination?: StrapiPagination;
@@ -92,7 +93,7 @@ export interface IServiceCommon {
     fieldName: string,
     value: any
   ): Promise<boolean>;
-  sanitizeCommentEntity(entity: Comment, populate?: StringMap<boolean | Array<string> | StringMap<unknown>>): Comment;
+  sanitizeCommentEntity(entity: Comment, populate?: PopulateClause<OnlyStrings<keyof StrapiUser>>): Comment;
   isValidUserContext(user?: any): boolean;
   parseRelationString(
     relation: string

--- a/yarn.lock
+++ b/yarn.lock
@@ -804,6 +804,17 @@
     lodash "4.17.21"
     yup "0.32.9"
 
+"@strapi/utils@4.1.8", "@strapi/utils@^4.1.8":
+  version "4.1.8"
+  resolved "https://registry.yarnpkg.com/@strapi/utils/-/utils-4.1.8.tgz#22c5b10b145f0ce005aefdb5611552ac73d02b23"
+  integrity sha512-FMC9gNQ+cXQNRkOaIiom6NlMIqqzo1gA9W/MkR/qezKIsivp+2nC+RsY4amS70D58yU/kjr1BdN5FtnwuyzOLQ==
+  dependencies:
+    "@sindresorhus/slugify" "1.1.0"
+    date-fns "2.24.0"
+    http-errors "1.8.0"
+    lodash "4.17.21"
+    yup "0.32.9"
+
 "@szmarczak/http-timer@^1.1.2":
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@szmarczak/http-timer/-/http-timer-1.1.2.tgz#b1665e2c461a2cd92f4c1bbf50d5454de0d4b421"

--- a/yarn.lock
+++ b/yarn.lock
@@ -804,17 +804,6 @@
     lodash "4.17.21"
     yup "0.32.9"
 
-"@strapi/utils@4.1.8", "@strapi/utils@^4.1.8":
-  version "4.1.8"
-  resolved "https://registry.yarnpkg.com/@strapi/utils/-/utils-4.1.8.tgz#22c5b10b145f0ce005aefdb5611552ac73d02b23"
-  integrity sha512-FMC9gNQ+cXQNRkOaIiom6NlMIqqzo1gA9W/MkR/qezKIsivp+2nC+RsY4amS70D58yU/kjr1BdN5FtnwuyzOLQ==
-  dependencies:
-    "@sindresorhus/slugify" "1.1.0"
-    date-fns "2.24.0"
-    http-errors "1.8.0"
-    lodash "4.17.21"
-    yup "0.32.9"
-
 "@szmarczak/http-timer@^1.1.2":
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@szmarczak/http-timer/-/http-timer-1.1.2.tgz#b1665e2c461a2cd92f4c1bbf50d5454de0d4b421"
@@ -4320,10 +4309,10 @@ typedarray-to-buffer@^3.1.5:
   dependencies:
     is-typedarray "^1.0.0"
 
-typescript@^4.5.5:
-  version "4.6.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.6.2.tgz#fe12d2727b708f4eef40f51598b3398baa9611d4"
-  integrity sha512-HM/hFigTBHZhLXshn9sN37H085+hQGeJHJ/X7LpBWLID/fbc2acUMfU+lGD98X81sKP+pFa9f0DZmCwB9GnbAg==
+typescript@^4.6.3:
+  version "4.6.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.6.3.tgz#eefeafa6afdd31d725584c67a0eaba80f6fc6c6c"
+  integrity sha512-yNIatDa5iaofVozS/uQJEl3JRWLKKGJKh6Yaiv0GLGSuhpFJe7P3SbHZ8/yjAHRQwKRoA6YZqlfjXWmVzoVSMw==
 
 undefsafe@^2.0.5:
   version "2.0.5"


### PR DESCRIPTION
## Ticket

https://github.com/VirtusLab/strapi-plugin-comments/issues/113

## Summary

What does this PR do/solve? 

Provides ability to populate author field and all fields related to it.

> Note
> PR #132 must be merged first

## Test Plan

### Scenario 1
1. Run application
2. Add couple comments using Strapi Users (Authenticated)
3. Try to call REST API as 
   `api/comments/api::page.page:1/flat?populate[author][populate][0]=role`
4. See that `role` is part of the `author` per each comment

### Scenario 2
1. Run application
2. Provide an `avatar` field to the `User` Collection and set it for your test users
3. Add couple comments using Strapi Users (Authenticated)
3. Try to call REST API as 
   `api/comments/api::page.page:1/flat?populate[author][populate][0]=role&populate[author][populate][1]=avatar`
4. See that `role` is part of the `author` per each comment as well as `avatar`
5. Check the Moderation panel and see that avatar is also visible on the list of comments and their details