### PR TITLE
CU-2dz37t8 - issue 137 - comments are broken if user was deleted

### DIFF
--- a/admin/src/components/DiscussionThreadItemFooter/index.tsx
+++ b/admin/src/components/DiscussionThreadItemFooter/index.tsx
@@ -16,6 +16,7 @@ import {
   DiscussionThreadItemFooterStyled,
 } from "./styles";
 import UserAvatar from "../Avatar";
+import { getMessage } from "../../utils";
 
 const DiscussionThreadItemFooter = ({
   children,
@@ -29,14 +30,14 @@ const DiscussionThreadItemFooter = ({
     dateStyle: "medium",
     timeStyle: "short",
   });
-  const { name, avatar } = author;
+  const { name, avatar } = author || {};
 
   return (
     <DiscussionThreadItemFooterStyled as={Box} paddingTop={2} direction="row">
       <DiscussionThreadItemFooterMeta size={3} horizontal>
-        <UserAvatar avatar={avatar} name={name} />
+        { author && (<UserAvatar avatar={avatar} name={name} />) }
         <Typography variant="pi" fontWeight="bold" textColor="neutral800">
-          {name}
+          {name || getMessage('compontents.author.unknown')}
         </Typography>
         <Typography variant="pi" textColor="neutral600">
           {dateTime}

--- a/admin/src/pages/Discover/components/DiscoverTableRow/index.tsx
+++ b/admin/src/pages/Discover/components/DiscoverTableRow/index.tsx
@@ -153,9 +153,9 @@ const DiscoverTableRow = ({
       </Td>
       <Td>
         <Stack size={2} horizontal>
-          <UserAvatar avatar={item.author?.avatar} name={item.author.name} />
+          { item.author && (<UserAvatar avatar={item?.author?.avatar} name={item?.author?.name} />) }
           <Typography textColor="neutral800" variant="pi">
-            {item.author.name}
+            {item?.author?.name || getMessage('compontents.author.unknown')}
           </Typography>
         </Stack>
       </Td>

--- a/admin/src/translations/en.json
+++ b/admin/src/translations/en.json
@@ -128,5 +128,6 @@
   "compontents.confirmation.dialog.button.confirm": "Yes, I do",
   "compontents.confirmation.dialog.button.cancel": "Cancel",
   "compontents.toogle.enabled": "Enabled",
-  "compontents.toogle.disabled": "Disabled"
+  "compontents.toogle.disabled": "Disabled",
+  "compontents.author.unknown": "Author removed"
 }

--- a/admin/src/translations/fr.json
+++ b/admin/src/translations/fr.json
@@ -128,5 +128,6 @@
   "compontents.confirmation.dialog.button.confirm": "Oui, je le veux",
   "compontents.confirmation.dialog.button.cancel": "Annuler",
   "compontents.toogle.enabled": "Activé",
-  "compontents.toogle.disabled": "Désactivé"
+  "compontents.toogle.disabled": "Désactivé",
+  "compontents.author.unknown": "Auteur supprimé"
 }

--- a/admin/src/translations/pt-BR.json
+++ b/admin/src/translations/pt-BR.json
@@ -128,5 +128,6 @@
   "compontents.confirmation.dialog.button.confirm": "Sim eu quero",
   "compontents.confirmation.dialog.button.cancel": "Cancelar",
   "compontents.toogle.enabled": "Habilitado",
-  "compontents.toogle.disabled": "Desabilitado"
+  "compontents.toogle.disabled": "Desabilitado",
+  "compontents.author.unknown": "Autor removido"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "strapi-plugin-comments",
-  "version": "2.1.4",
+  "version": "2.1.5",
   "description": "Strapi - Comments plugin",
   "strapi": {
     "name": "comments",


### PR DESCRIPTION
## Ticket

https://github.com/VirtusLab/strapi-plugin-comments/issues/137

## Summary

What does this PR do/solve?

Covers case when Strapi User was removed and still got some comments assigned. Prevents interface crashes.

## Test Plan

1. Create Strapi User
2. Add comment associated to newly created user
3. Remove user
4. See that `Author removed` is visible instead of name and interface is not crashing
