### PR TITLE
feat: custom fields on server-side [CU-xhcmx-63]

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -3,7 +3,7 @@ import { defaults as tsjPreset } from "ts-jest/presets";
 
 const config: Config.InitialOptions = {
   name: "Unit test",
-  testMatch: ["**/__tests__/?(*.)+(spec|test).ts"],
+  testMatch: ["**/__tests__/?(*.)+(spec|test).(t|j)s"],
   transform: {
     ...tsjPreset.transform,
   },

--- a/server/controllers/utils/__tests__/functions.test.js
+++ b/server/controllers/utils/__tests__/functions.test.js
@@ -8,13 +8,13 @@ describe("Test Comments controller functions utils", () => {
   describe("Errors serialization", () => {
     test("Should throw error PluginError", () => {
       try {
-        throw new PluginError(400, "Error message", {
+        throw new PluginError.default(400, "Error message", {
           content: {
             param: "Parameter value",
           },
         });
       } catch (e) {
-        expect(e).toBeInstanceOf(PluginError);
+        expect(e).toBeInstanceOf(PluginError.default);
         expect(e).toHaveProperty("status", 400);
         expect(e).toHaveProperty("name", "Strapi:Plugin:Comments");
         expect(e).toHaveProperty("message", "Error message");

--- a/server/controllers/utils/__tests__/parsers.test.js
+++ b/server/controllers/utils/__tests__/parsers.test.js
@@ -20,14 +20,14 @@ describe("Test Comments controller parsers utils", () => {
     const fields = ["content"];
 
     test("Should contain default property 'populate'", () => {
-      expect(flatInput()).toHaveProperty(
+      expect(flatInput({ query: {} })).toHaveProperty(
         ["populate", "threadOf", "populate", "authorUser"],
         true
       );
     });
 
     test("Should assign relation to 'query'", () => {
-      expect(flatInput({ relation })).toHaveProperty(
+      expect(flatInput({ relation, query: {} })).toHaveProperty(
         ["query", "related"],
         relation
       );
@@ -158,6 +158,70 @@ describe("Test Comments controller parsers utils", () => {
         ["pagination", "pageSize"],
         pagination.pageSize
       );
+    });
+
+    test("Should assign filtering by comments status", () => {
+      const filterByValue = "APPROVED";
+      const result = flatInput({
+        relation,
+        query: {
+          ...query,
+          filterBy: "APPROVAL_STATUS",
+          filterByValue,
+        },
+        sort,
+        fields,
+      });
+
+      expect(result).toHaveProperty(["query", "approvalStatus"], filterByValue);
+      expect(() => {
+        flatInput({
+          relation,
+          query: {
+            filterBy: "APPROVAL_STATUS",
+          },
+          sort,
+          fields,
+        });
+      }).toThrow();
+    });
+
+    test("Should assign filtering by creation date", () => {
+      const filterByValue = new Date().toUTCString();
+      const result = flatInput({
+        relation,
+        query: {
+          ...query,
+          filterBy: "DATE_CREATED",
+          filterByValue,
+        },
+        sort,
+        fields,
+      });
+
+      expect(result).toHaveProperty(["query", "createdAt", "$between", 0]);
+      expect(result).toHaveProperty(["query", "createdAt", "$between", 1]);
+      expect(() => {
+        flatInput({
+          relation,
+          query: {
+            filterBy: "DATE_CREATED",
+          },
+          sort,
+          fields,
+        });
+      }).toThrow();
+      expect(() => {
+        flatInput({
+          relation,
+          query: {
+            filterByValue: "X",
+            filterBy: "DATE_CREATED",
+          },
+          sort,
+          fields,
+        });
+      }).toThrow();
     });
   });
 });

--- a/server/controllers/utils/parsers.ts
+++ b/server/controllers/utils/parsers.ts
@@ -1,12 +1,14 @@
 import { OnlyStrings } from "strapi-typed";
 import { FlatInput, ToBeFixed } from "../../../types";
+import PluginError from "../../utils/error";
+import { assertNotEmpty } from "../../utils/functions";
 
 export const flatInput = <T, TKeys = keyof T>(
   payload: FlatInput<OnlyStrings<TKeys>>
 ) => {
   const { relation, query, sort, pagination, fields } = payload;
 
-  const { populate = {}, ...restQuery } = query;
+  const { populate = {}, filterBy, filterByValue, ...restQuery } = query;
   const filters = restQuery?.filters || restQuery;
   const orOperator = (filters?.$or || []).filter(
     (_: ToBeFixed) => !Object.keys(_).includes("removed")
@@ -40,6 +42,30 @@ export const flatInput = <T, TKeys = keyof T>(
         },
       },
     };
+  }
+
+  if (filterBy === "DATE_CREATED") {
+    const date = new Date(filterByValue);
+
+    if (!filterByValue || Number.isNaN(+date)) {
+      throw new PluginError(400, 'Invalid date specified in "filterByValue"');
+    }
+
+    const start = date.setHours(0, 0, 0, 0);
+    const end = date.setHours(23, 59, 59, 999);
+
+    filters.createdAt = {
+      $between: [start, end],
+    };
+  }
+
+  if (filterBy === "APPROVAL_STATUS") {
+    assertNotEmpty(
+      filterByValue,
+      new PluginError(400, 'Empty "filterByValue" parameter')
+    );
+
+    filters.approvalStatus = filterByValue;
   }
 
   return {

--- a/server/graphql/queries/findAllInHierarchy.ts
+++ b/server/graphql/queries/findAllInHierarchy.ts
@@ -20,12 +20,16 @@ export = ({ strapi, nexus }: StrapiGraphQLContext) => {
   const { nonNull, list, stringArg } = nexus;
   const { service: getService } = strapi.plugin("graphql");
   const { args } = getService("internals");
+  const {
+    naming: { getFiltersInputTypeName },
+  } = getService("utils");
 
   return {
     type: nonNull(list("CommentNested")),
     args: {
       relation: nonNull(stringArg()),
       sort: args.SortArg,
+      filters: getFiltersInputTypeName(contentType),
     },
     // @ts-ignore
     async resolve(obj: Object, args: findAllInHierarchyProps) {

--- a/server/services/utils/__tests__/functions.test.js
+++ b/server/services/utils/__tests__/functions.test.js
@@ -27,7 +27,7 @@ describe("Test service functions utils", () => {
       try {
         resolveUserContextError({ id: 1 });
       } catch (e) {
-        expect(e).toBeInstanceOf(PluginError);
+        expect(e).toBeInstanceOf(PluginError.default);
         expect(e).toHaveProperty("status", 401);
       }
     });
@@ -36,7 +36,7 @@ describe("Test service functions utils", () => {
       try {
         resolveUserContextError();
       } catch (e) {
-        expect(e).toBeInstanceOf(PluginError);
+        expect(e).toBeInstanceOf(PluginError.default);
         expect(e).toHaveProperty("status", 403);
       }
     });


### PR DESCRIPTION
## Ticket

https://app.clickup.com/30978717/v/b/xhcmx-63

## Summary

- Server side handling of filtering by parameters that can be found in newly added `comments` custom field
- tests expand
- including JS test suites
- fixes for failing tests

## Test Plan

Perform calls like:

- http://localhost:1337/api/comments/api::page.page:5/flat?filterBy=DATE_CREATED&filterByValue=2022-10-12T13:21:13.595Z
- http://localhost:1337/api/comments/api::page.page:5/flat?filterBy=APPROVAL_STATUS&filterByValue=APPROVED
