### PR TITLE
fix: custom field on existing entity

### DIFF
--- a/admin/src/custom-fields/comments/components/input/consts.ts
+++ b/admin/src/custom-fields/comments/components/input/consts.ts
@@ -1,0 +1,7 @@
+import { CommentsFieldValue } from "./types";
+
+export const DEFAULTS: CommentsFieldValue = {
+  commentsNumber: 30,
+  populate: [],
+  renderType: "FLAT",
+};

--- a/admin/src/custom-fields/comments/components/input/input.tsx
+++ b/admin/src/custom-fields/comments/components/input/input.tsx
@@ -39,12 +39,7 @@ import {
 } from "./utils";
 import { getMessage } from "../../../../utils";
 import { useIntl } from "react-intl";
-
-const DEFAULTS: CommentsFieldValue = {
-  commentsNumber: 30,
-  populate: [],
-  renderType: "FLAT",
-};
+import { DEFAULTS } from "./consts";
 
 export const CustomFieldInput: React.FC<CustomFieldInputProps> = ({
   attribute,

--- a/admin/src/custom-fields/comments/components/input/utils.ts
+++ b/admin/src/custom-fields/comments/components/input/utils.ts
@@ -7,13 +7,22 @@ import {
   assertString,
 } from "../../../../utils";
 import { CommentsFieldValue, PopulateField } from "./types";
+import { DEFAULTS } from "./consts";
 
 export const asString = () => "";
 
 export const fromInput = (value: unknown) => {
   assertString(value);
 
-  const state = JSON.parse(value);
+  let state = JSON.parse(value);
+
+  if (!state) {
+    console.group("[Comments]");
+    console.warn("Empty state provided from the back-end");
+    console.groupEnd();
+
+    state = DEFAULTS
+  }
 
   assertCorrectState(state);
 


### PR DESCRIPTION
## Ticket

https://github.com/VirtusLab-Open-Source/strapi-plugin-comments/issues/175

## Summary

What does this PR do/solve?

This PR fixes error happening when custom field is added to already existing entity.

## Test Plan

1. Create a content type
2. Create content type's item
3. Add comments custom field
4. Edit existing item
5. No error should be presented
6. Warning should be present in browser's console
