### PR TITLE
fix: [CU-862hz23aa] Translations init failure while async loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ In our minimum support we're following [official Node.js releases timelines](htt
 
 **Supported Strapi versions**:
 
-- Strapi v4.5.4 (recently tested)
+- Strapi v4.5.5 (recently tested)
 - Strapi v4.x
 
 > This plugin is designed for **Strapi v4** and is not working with v3.x. To get version for **Strapi v3** install version [v1.x](https://github.com/VirtusLab-Open-Source/strapi-plugin-comments/tree/strapi-v3).

--- a/admin/src/index.ts
+++ b/admin/src/index.ts
@@ -1,5 +1,6 @@
 // @ts-ignore
 import { prefixPluginTranslations } from "@strapi/helper-plugin";
+import { get } from 'lodash';
 import { StrapiAdminInstance } from "strapi-typed";
 import * as pluginPkg from "../../package.json";
 import { pluginId } from "./pluginId";
@@ -7,8 +8,8 @@ import Initializer from "./components/Initializer";
 import PluginIcon from "./components/PluginIcon";
 import pluginPermissions from "./permissions";
 import reducers from "./reducers";
-import { ToBeFixed } from "../../types";
 import { registerCustomFields } from "./custom-fields";
+import trads, { TranslationKey, Translations } from "./translations";
 
 const { name, displayName } = pluginPkg.strapi;
 
@@ -78,25 +79,12 @@ export default {
   //   // });
   // },
 
-  async registerTrads({ locales }: ToBeFixed) {
-    const importedTrads = await Promise.all(
-      locales.map((locale: ToBeFixed) => {
-        return import(`./translations/${locale}.json`)
-          .then(({ default: data }) => {
-            return {
-              data: prefixPluginTranslations(data, pluginId),
-              locale,
-            };
-          })
-          .catch(() => {
-            return {
-              data: {},
-              locale,
-            };
-          });
-      })
-    );
-
-    return Promise.resolve(importedTrads);
+  registerTrads({ locales }: { locales: Array<TranslationKey>}) {
+    return locales.map((locale: string) => {
+      return {
+        data: prefixPluginTranslations(get<Translations, TranslationKey>(trads, locale as TranslationKey), pluginId, {}),
+        locale,
+      };
+    });
   },
 };

--- a/admin/src/translations/index.ts
+++ b/admin/src/translations/index.ts
@@ -1,0 +1,17 @@
+import { KeyValueSet } from "strapi-typed";
+import en from "./en.json";
+import fr from "./fr.json";
+import ptBr from "./pt-BR.json";
+
+export type TranslationKey = "en" | "fr" | "pt-BR";
+export type Translations = {
+  [key in TranslationKey]: KeyValueSet<string>
+};
+
+const trads: Translations = {
+  en,
+  fr,
+  "pt-BR": ptBr,
+};
+
+export default trads;

--- a/admin/src/utils/getMessage.ts
+++ b/admin/src/utils/getMessage.ts
@@ -1,6 +1,4 @@
 import { useIntl } from "react-intl";
-import { isString } from "lodash";
-
 import { pluginId } from "../pluginId";
 import { ToBeFixed } from "../../../types";
 
@@ -11,18 +9,17 @@ const getMessage = (
 ) => {
   const { formatMessage } = useIntl();
   let formattedId = "";
-  if (isString(input)) {
+  if (typeof input === 'string') {
     formattedId = input;
   } else {
-    formattedId = input?.id;
+    formattedId = input?.id.toString() || formattedId;
   }
-
   return formatMessage(
     {
       id: `${inPluginScope ? pluginId : "app.components"}.${formattedId}`,
       defaultMessage,
     },
-    input?.props,
+    typeof input === 'string' ? undefined : input?.props,
   );
 };
 

--- a/package.json
+++ b/package.json
@@ -27,8 +27,8 @@
     "url": "https://github.com/VirtusLab-Open-Source/strapi-plugin-comments"
   },
   "dependencies": {
-    "@strapi/plugin-graphql": "^4.5.4",
-    "@strapi/utils": "^4.5.4",
+    "@strapi/plugin-graphql": "^4.5.5",
+    "@strapi/utils": "^4.5.5",
     "@types/axios": "^0.14.0",
     "@types/react-intl": "^3.0.0",
     "@types/react-query": "^1.2.9",
@@ -37,9 +37,9 @@
     "styled-components": "^5.3.6"
   },
   "devDependencies": {
-    "@strapi/helper-plugin": "^4.5.4",
     "@types/bad-words": "^3.0.1",
     "@types/jest": "^27.4.1",
+    "@strapi/helper-plugin": "^4.5.5",
     "codecov": "^3.7.2",
     "copyfiles": "^2.4.1",
     "husky": "7.0.4",


### PR DESCRIPTION
## Ticket

https://github.com/VirtusLab/strapi-plugin-comments/issues/180

## Summary

What does this PR do/solve?

Solves failure for `async` loading of translations. Method has been changed to synchronous.

## Test Plan

1. Run the app
2. See that translations are loading properly