### PR TITLE
feat: author entity props blocking

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,7 @@ module.exports = ({ env }) => ({
         "*": ["Title", "title", "Name", "name", "Subject", "subject"],
         "api::page.page": ["MyField"],
       },
+      blockedAuthorProps: ["name", "email"],
       reportReasons: {
         MY_CUSTOM_REASON: "MY_CUSTOM_REASON",
       },
@@ -197,6 +198,7 @@ module.exports = ({ env }) => ({
 - `entryLabel` - ordered list of property names per Content Type to generate related entity label. Keys must be in format like `'api::<collection name>.<content type name>'`. Default formatting set as `*`.
 - `reportReasons` - set of enums you would like to use for issuing abuse reports. Provided by default `'BAD_LANGUAGE'`, `'DISCRIMINATION'` and `'OTHER'`.
 - `gql` - specific configuration for GraphQL. See [Additional GQL Configuration](#additional-gql-configuration)
+- `blockedAuthorProps` - list of author's entity properties removed from a response for client side
 
 ## Additional GQL Configuration
 

--- a/admin/src/components/Avatar/index.tsx
+++ b/admin/src/components/Avatar/index.tsx
@@ -17,25 +17,41 @@ import AdminAvatar from "../AdminAvatar";
 import { ToBeFixed } from "../../../../types";
 
 interface IProps {
-    avatar: string | ToBeFixed; 
-    name: string;
-    isAdminComment?: boolean;
-};
+  avatar: string | ToBeFixed;
+  avatar: string | ToBeFixed;
+  avatar: string | ToBeFixed;
+  name: string;
+  isAdminComment?: boolean;
+}
 
-const UserAvatar: React.FC<IProps> = ({ avatar, name, isAdminComment = false }) => {
+const UserAvatar: React.FC<IProps> = ({
+  avatar,
+  name,
+  isAdminComment = false,
+}) => {
   if (avatar) {
     let image = avatar;
+
     if (isObject(avatar)) {
       image = avatar?.formats?.thumbnail.url || avatar.url;
     }
-      return(
-        isAdminComment ? <AdminAvatar>{image && (<Avatar src={image} alt={name} />)}</AdminAvatar>
-        : image && (<Avatar src={image} alt={name} />))
-      }
-  return(
-    isAdminComment ? <AdminAvatar>{name && (<Initials>{renderInitials(name)}</Initials>)}</AdminAvatar>
-    : name && (<Initials>{renderInitials(name)}</Initials>)
-  ) 
+
+    return isAdminComment ? (
+      <AdminAvatar>
+        {image ? <Avatar src={image} alt={name} /> : null}
+      </AdminAvatar>
+    ) : image ? (
+      <Avatar src={image} alt={name} />
+    ) : null;
+  }
+
+  return isAdminComment ? (
+    <AdminAvatar>
+      {name ? <Initials>{renderInitials(name)}</Initials> : null}
+    </AdminAvatar>
+  ) : name ? (
+    <Initials>{renderInitials(name)}</Initials>
+  ) : null;
 };
 
 export default UserAvatar;

--- a/admin/src/components/Avatar/index.tsx
+++ b/admin/src/components/Avatar/index.tsx
@@ -18,8 +18,6 @@ import { ToBeFixed } from "../../../../types";
 
 interface IProps {
   avatar: string | ToBeFixed;
-  avatar: string | ToBeFixed;
-  avatar: string | ToBeFixed;
   name: string;
   isAdminComment?: boolean;
 }

--- a/admin/src/pages/Settings/index.tsx
+++ b/admin/src/pages/Settings/index.tsx
@@ -176,6 +176,7 @@ const Settings = () => {
     ) || [];
   const clientUrl = configData?.client?.url;
   const clientEmail = configData?.client?.contactEmail;
+  const blockedAuthorProps = configData?.blockedAuthorProps ?? [];
 
   const changeApprovalFlowFor = (
     uid: ToBeFixed,
@@ -261,6 +262,7 @@ const Settings = () => {
           clientEmail,
           clientUrl,
           gqlAuthEnabled,
+          blockedAuthorProps,
         }}
         enableReinitialize={true}
         onSubmit={handleUpdateConfiguration}
@@ -489,7 +491,7 @@ const Settings = () => {
                       {getMessage("page.settings.section.additional")}
                     </Typography>
                     <Grid gap={4}>
-                      <GridItem col={6} xs={12}>
+                      <GridItem col={4} xs={12}>
                         <ToggleInput
                           name="badWords"
                           label={getMessage(
@@ -505,8 +507,23 @@ const Settings = () => {
                           disabled={restartRequired}
                         />
                       </GridItem>
+                      <GridItem col={4} xs={12}>
+                        <TextInput
+                          type="text"
+                          name="blockedAuthorProps"
+                          label={getMessage(
+                            "page.settings.form.author.blockedProps.label"
+                          )}
+                          hint={getMessage("page.settings.form.author.blockedProps.hint")}
+                          value={values.blockedAuthorProps.join(", ")}
+                          onChange={({ target: { value } }: ToBeFixed) =>
+                            setFieldValue("blockedAuthorProps", value.split(', ').map(_ => _.trim()), false)
+                          }
+                          disabled={restartRequired}
+                        />
+                      </GridItem>
                       {isGQLPluginEnabled && (
-                        <GridItem col={6} xs={12}>
+                        <GridItem col={4} xs={12}>
                           <ToggleInput
                             name="gqlAuthEnabled"
                             label={getMessage(

--- a/admin/src/translations/en.json
+++ b/admin/src/translations/en.json
@@ -157,6 +157,8 @@
   "page.settings.notification.restart.success": "Application has been restarted successfully",
   "page.settings.notification.restart.error": "Failed to restart your application. Try to do it manually.",
   "page.settings.loading": "Fetching configuration...",
+  "page.settings.form.author.blockedProps.label": "Blocked author details",
+  "page.settings.form.author.blockedProps.hint": "Specified properties will be filtered out from author's details (comma-separated)",
   "compontents.confirmation.dialog.header": "Confirmation",
   "compontents.confirmation.dialog.description": "Do you really want to perform this action?",
   "compontents.confirmation.dialog.button.confirm": "Yes, I do",

--- a/server/config/index.ts
+++ b/server/config/index.ts
@@ -13,6 +13,7 @@ const config: StrapiConfig = {
       DISCRIMINATION: "DISCRIMINATION",
       OTHER: "OTHER",
     },
+    blockedAuthorProps: [],
   },
 };
 

--- a/server/services/__tests__/common.test.ts
+++ b/server/services/__tests__/common.test.ts
@@ -138,7 +138,7 @@ describe("Test Comments service - Common", () => {
     test("Should return exact the same value", () => {
       const input = { ...sample };
       const output =
-        getPluginService<IServiceCommon>("common").sanitizeCommentEntity(input);
+        getPluginService<IServiceCommon>("common").sanitizeCommentEntity(input, []);
       expect(output).toHaveProperty("id", input.id);
       expect(output).toHaveProperty("content", input.content);
       expect(output).toHaveProperty("blocked", input.blocked);
@@ -151,7 +151,7 @@ describe("Test Comments service - Common", () => {
         ...authorGenericSample,
       };
       const output =
-        getPluginService<IServiceCommon>("common").sanitizeCommentEntity(input);
+        getPluginService<IServiceCommon>("common").sanitizeCommentEntity(input, []);
 
       expect(output).toHaveProperty("author");
       expect(output).toHaveProperty("author.id", input.authorId);
@@ -172,7 +172,7 @@ describe("Test Comments service - Common", () => {
         authorUser: authorSample,
       };
       const output =
-        getPluginService<IServiceCommon>("common").sanitizeCommentEntity(input);
+        getPluginService<IServiceCommon>("common").sanitizeCommentEntity(input, []);
 
       expect(output).toHaveProperty("author");
       expect(output).toHaveProperty("author.id", input.authorUser.id);
@@ -186,6 +186,24 @@ describe("Test Comments service - Common", () => {
 
       expect(output).not.toHaveProperty("author.password");
     });
+
+    test("Should filter out author properties", () => {
+      const input = {
+        ...sample,
+        authorUser: authorSample,
+      };
+      const output =
+        getPluginService<IServiceCommon>("common").sanitizeCommentEntity(input, ["email"]);
+
+      expect(output).toHaveProperty("author");
+      expect(output).toHaveProperty("author.id", outputAuthorSample.id);
+      expect(output).toHaveProperty("author.name", outputAuthorSample.name);
+      expect(output).not.toHaveProperty("author.email");
+
+      expect(output).not.toHaveProperty("authorUser");
+
+      expect(output).not.toHaveProperty("author.password");
+    })
   });
 
   describe("Bad Words filtering", () => {
@@ -453,10 +471,10 @@ describe("Test Comments service - Common", () => {
         expect(result).toHaveProperty("data");
         expect(result).not.toHaveProperty("meta");
         expect(result.data.length).toBe(4);
-        expect(Object.keys(filterOutUndefined(result.data[0]))).toHaveLength(6);
-        expect(Object.keys(filterOutUndefined(result.data[1]))).toHaveLength(6);
-        expect(Object.keys(filterOutUndefined(result.data[2]))).toHaveLength(6);
-        expect(Object.keys(filterOutUndefined(result.data[3]))).toHaveLength(6);
+        expect(Object.keys(filterOutUndefined(result.data[0]))).toHaveLength(7);
+        expect(Object.keys(filterOutUndefined(result.data[1]))).toHaveLength(7);
+        expect(Object.keys(filterOutUndefined(result.data[2]))).toHaveLength(7);
+        expect(Object.keys(filterOutUndefined(result.data[3]))).toHaveLength(7);
       });
 
       test("Should return structure with populated avatar field", async () => {

--- a/server/services/admin.ts
+++ b/server/services/admin.ts
@@ -208,6 +208,7 @@ export = ({ strapi }: StrapiContext): IServiceAdmin => ({
         filterOurResolvedReports(
           this.getCommonService().sanitizeCommentEntity(
             _,
+            [],
             defaultAuthorUserPopulate?.populate,
           ),
         ),
@@ -319,8 +320,9 @@ export = ({ strapi }: StrapiContext): IServiceAdmin => ({
             related: this.getCommonService().sanitizeCommentEntity({
               ..._.related,
               gotThread: isCommentWithThread,
-            }),
+            }, []),
           },
+          [],
           defaultAuthorUserPopulate?.populate,
         ),
       );
@@ -440,6 +442,7 @@ export = ({ strapi }: StrapiContext): IServiceAdmin => ({
         ...entity,
         threadOf: entity.threadOf || null,
       },
+      [],
       defaultAuthorUserPopulate?.populate,
     );
 
@@ -465,7 +468,7 @@ export = ({ strapi }: StrapiContext): IServiceAdmin => ({
           blocked: !isNil(forceStatus) ? forceStatus : !existingEntity.blocked,
         },
       });
-    return this.getCommonService().sanitizeCommentEntity(changedEntity);
+    return this.getCommonService().sanitizeCommentEntity(changedEntity, []);
   },
 
   // Delete a comment
@@ -482,7 +485,7 @@ export = ({ strapi }: StrapiContext): IServiceAdmin => ({
           removed: true,
         },
       });
-    return this.getCommonService().sanitizeCommentEntity(changedEntity);
+    return this.getCommonService().sanitizeCommentEntity(changedEntity, []);
   },
 
   // Block / Unblock a comment thread
@@ -506,7 +509,7 @@ export = ({ strapi }: StrapiContext): IServiceAdmin => ({
       });
     await this.blockNestedThreads(id, changedEntity.blockedThread);
 
-    return this.getCommonService().sanitizeCommentEntity(changedEntity);
+    return this.getCommonService().sanitizeCommentEntity(changedEntity, []);
   },
 
   // Approve comment
@@ -518,7 +521,7 @@ export = ({ strapi }: StrapiContext): IServiceAdmin => ({
         data: { approvalStatus: APPROVAL_STATUS.APPROVED },
       });
 
-    return this.getCommonService().sanitizeCommentEntity(changedEntity);
+    return this.getCommonService().sanitizeCommentEntity(changedEntity, []);
   },
 
   async rejectComment(this: IServiceAdmin, id: Id): Promise<Comment> {
@@ -529,7 +532,7 @@ export = ({ strapi }: StrapiContext): IServiceAdmin => ({
         data: { approvalStatus: APPROVAL_STATUS.REJECTED },
       });
 
-    return this.getCommonService().sanitizeCommentEntity(changedEntity);
+    return this.getCommonService().sanitizeCommentEntity(changedEntity, []);
   },
 
   async blockNestedThreads(
@@ -751,7 +754,7 @@ export = ({ strapi }: StrapiContext): IServiceAdmin => ({
           content: body
         }
       });
-    return this.getCommonService().sanitizeCommentEntity(updateComment);
+    return this.getCommonService().sanitizeCommentEntity(updateComment, []);
   },
 
   // Recognize Strapi User fields possible to populate

--- a/server/services/admin.ts
+++ b/server/services/admin.ts
@@ -86,9 +86,12 @@ export = ({ strapi }: StrapiContext): IServiceAdmin => ({
     const entryLabel = getConfigProp<"entryLabel">("entryLabel");
     const approvalFlow = getConfigProp<"approvalFlow">("approvalFlow");
     const reportReasons = getConfigProp<"reportReasons">("reportReasons");
+    const blockedAuthorProps = getConfigProp<"blockedAuthorProps">("blockedAuthorProps");
+
     const result = {
       entryLabel,
       approvalFlow,
+      blockedAuthorProps,
       reportReasons,
       ...additionalConfiguration,
     };

--- a/server/services/utils/functions.ts
+++ b/server/services/utils/functions.ts
@@ -95,7 +95,8 @@ export const convertContentTypeNameToSlug = (str: string): string => {
 
 export const buildAuthorModel = (
   item: Comment,
-  fieldsToPopulate: Array<string> = []
+  blockedAuthorProps: Array<string>,
+  fieldsToPopulate: Array<string> = [],
 ): Comment => {
   const {
     authorUser,
@@ -106,6 +107,7 @@ export const buildAuthorModel = (
     ...rest
   } = item;
   let author: CommentAuthor = {} as CommentAuthor;
+
   if (authorUser) {
     author = fieldsToPopulate.reduce(
       (prev, curr) => ({
@@ -130,9 +132,15 @@ export const buildAuthorModel = (
       avatar: authorAvatar,
     };
   }
+
+  author = isEmpty(author) ? author : Object.fromEntries(
+    Object.entries(author)
+      .filter(([name]) => !blockedAuthorProps.includes(name))
+  ) as CommentAuthor;
+
   return {
     ...rest,
-    author: isEmpty(author) ? undefined : author,
+    author,
   };
 };
 

--- a/server/utils/constants.ts
+++ b/server/utils/constants.ts
@@ -6,6 +6,7 @@ export const CONFIG_PARAMS: ConfigParamKeys = {
   ENTRY_LABEL: "entryLabel",
   MODERATOR_ROLES: "moderatorRoles",
   BAD_WORDS: "badWords",
+  AUTHOR_BLOCKED_PROPS: "blockedAuthorProps",
 };
 
 export const APPROVAL_STATUS = {

--- a/types/config.d.ts
+++ b/types/config.d.ts
@@ -5,6 +5,7 @@ export type CommentsPluginConfig = StrapiPluginConfig<{
   enabledCollections: Array<string>;
   moderatorRoles: Array<string>;
   approvalFlow: Array<string>;
+  blockedAuthorProps: Array<string>;
   entryLabel: PluginConfigEntryLabels;
   reportReasons: PluginConfigReportReasons;
   badWords?: boolean;
@@ -25,6 +26,7 @@ export type PluginConfigKeys = keyof CommentsPluginConfig;
 
 export type ViewCommentsPluginConfig = {
   approvalFlow: TypeResult<SettingsCommentsPluginConfig["approvalFlow"]>;
+  blockedAuthorProps: TypeResult<SettingsCommentsPluginConfig["blockedAuthorProps"]>;
   entryLabel: TypeResult<SettingsCommentsPluginConfig["entryLabel"]>;
   reportReasons: TypeResult<SettingsCommentsPluginConfig["reportReasons"]>;
   regex?: RegExpCollection;

--- a/types/services.d.ts
+++ b/types/services.d.ts
@@ -98,7 +98,8 @@ export interface IServiceCommon {
   ): Promise<boolean>;
   sanitizeCommentEntity(
     entity: Comment,
-    populate?: PopulateClause<OnlyStrings<keyof StrapiUser>>
+    blockedAuthorProps: string[],
+    populate?: PopulateClause<OnlyStrings<keyof StrapiUser>>,
   ): Comment;
   isValidUserContext(user?: any): boolean;
   parseRelationString(


### PR DESCRIPTION
## Ticket

https://github.com/VirtusLab-Open-Source/strapi-plugin-comments/issues/183

## Summary

What does this PR do/solve?

- removing selected fields from author object in the response by config
- minor UI issue

## Test Plan

- set `blockedAuthorProps` in config
- query for comments
- blocked props should be blocked
