### PR TITLE
fix: author blocked props

### DIFF
--- a/admin/src/pages/Settings/index.tsx
+++ b/admin/src/pages/Settings/index.tsx
@@ -5,7 +5,7 @@ import React, { useRef, useMemo, useState } from "react";
 import { useQuery } from "react-query";
 // @ts-ignore
 import { Formik } from "formik";
-import { capitalize, first, orderBy, isEmpty, isEqual, isNil } from "lodash";
+import { capitalize, first, orderBy, isEmpty, isEqual, isNil, debounce } from "lodash";
 // @ts-ignore
 import {
   CheckPermissions,
@@ -112,9 +112,11 @@ const Settings = () => {
     entryLabel,
     clientUrl,
     clientEmail,
+    blockedAuthorProps,
     ...rest
   }: ToBeFixed) => ({
     ...rest,
+    blockedAuthorProps: blockedAuthorProps.split(",").map(x => x.trim()).filter(x => x),
     enabledCollections,
     approvalFlow: approvalFlow.filter((_) => enabledCollections.includes(_)),
     entryLabel: {
@@ -262,7 +264,7 @@ const Settings = () => {
           clientEmail,
           clientUrl,
           gqlAuthEnabled,
-          blockedAuthorProps,
+          blockedAuthorProps: blockedAuthorProps.join(", "),
         }}
         enableReinitialize={true}
         onSubmit={handleUpdateConfiguration}
@@ -515,9 +517,9 @@ const Settings = () => {
                             "page.settings.form.author.blockedProps.label"
                           )}
                           hint={getMessage("page.settings.form.author.blockedProps.hint")}
-                          value={values.blockedAuthorProps.join(", ")}
+                          value={values.blockedAuthorProps}
                           onChange={({ target: { value } }: ToBeFixed) =>
-                            setFieldValue("blockedAuthorProps", value.split(', ').map(_ => _.trim()), false)
+                            setFieldValue("blockedAuthorProps", value, false)
                           }
                           disabled={restartRequired}
                         />

--- a/admin/src/pages/Settings/index.tsx
+++ b/admin/src/pages/Settings/index.tsx
@@ -5,7 +5,7 @@ import React, { useRef, useMemo, useState } from "react";
 import { useQuery } from "react-query";
 // @ts-ignore
 import { Formik } from "formik";
-import { capitalize, first, orderBy, isEmpty, isEqual, isNil, debounce } from "lodash";
+import { capitalize, first, orderBy, isEmpty, isEqual, isNil } from "lodash";
 // @ts-ignore
 import {
   CheckPermissions,

--- a/server/services/common.ts
+++ b/server/services/common.ts
@@ -96,6 +96,7 @@ export = ({ strapi }: StrapiContext): IServiceCommon => ({
       sort,
       pagination,
       fields,
+      isAdmin = false,
     }: FindAllFlatProps<Comment>,
     relatedEntity: RelatedEntity | null = null
   ): Promise<StrapiPaginatedResponse<Comment>> {
@@ -105,9 +106,11 @@ export = ({ strapi }: StrapiContext): IServiceCommon => ({
       authorUser: true,
       ...(isObject(populate) ? populate : {}),
     };
-    const doNotPopulateAuthor: Array<string> = await this.getConfig<
-      Array<string>
-    >(CONFIG_PARAMS.AUTHOR_BLOCKED_PROPS, []);
+    const doNotPopulateAuthor: Array<string> = isAdmin 
+      ? [] 
+      : await this.getConfig<
+        Array<string>
+      >(CONFIG_PARAMS.AUTHOR_BLOCKED_PROPS, []);
 
     let queryExtension: StrapiDBQueryArgs<CommentModelKeys> = {};
 
@@ -292,11 +295,12 @@ export = ({ strapi }: StrapiContext): IServiceCommon => ({
       fields,
       startingFromId = null,
       dropBlockedThreads = false,
+      isAdmin = false,
     }: FindAllInHierarchyProps,
     relatedEntity?: RelatedEntity | null | boolean
   ): Promise<Array<Comment>> {
     const entities = await this.findAllFlat(
-      { query, populate, sort, fields },
+      { query, populate, sort, fields, isAdmin },
       relatedEntity
     );
     return buildNestedStructure(

--- a/types/services.d.ts
+++ b/types/services.d.ts
@@ -42,6 +42,7 @@ export type FindAllFlatProps<T, TFields = keyof T> = {
   sort?: StringMap<unknown>;
   fields?: StrapiRequestQueryFieldsClause<OnlyStrings<TFields>>;
   pagination?: StrapiPagination;
+  isAdmin?: boolean
 };
 
 export type FindAllInHierarchyProps = Omit<FindAllFlatProps, "pagination"> & {


### PR DESCRIPTION
## Ticket

[https://github.com/VirtusLab/strapi-plugin-comments/issues/-<your-ticket-#>](https://github.com/VirtusLab-Open-Source/strapi-plugin-comments/issues/190)

## Summary

- disable filtering of author entities for admin panel
- ", " changed to "," in admin's panel comments settings page

## Test Plan

- all author props are available for admins
- in settings page just "," can be used as items delimiter
