### PR TITLE
feat(api): issue #209 - find all by author

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ In our minimum support we're following [official Node.js releases timelines](htt
 
 **Supported Strapi versions**:
 
-- Strapi v4.9.2 (recently tested)
+- Strapi v4.10.5 (recently tested)
 - Strapi v4.x
 
 > This plugin is designed for **Strapi v4** and is not working with v3.x. To get version for **Strapi v3** install version [v1.x](https://github.com/VirtusLab-Open-Source/strapi-plugin-comments/tree/strapi-v3).
@@ -361,6 +361,50 @@ Return a flat structure of comments for specified instance of Content Type like 
 - [sorting](https://docs.strapi.io/developer-docs/latest/developer-resources/database-apis-reference/rest/sort-pagination.html#sorting)
 - [pagination](https://docs.strapi.io/developer-docs/latest/developer-resources/database-apis-reference/rest/sort-pagination.html#pagination)
 
+### Get Comments (by Author)
+
+_GraphQL equivalent: [Public GraphQL API -> Get Comments (by Author)](#get-comments-by-author-1)_
+
+`GET <host>/api/comments/author/<id>/<?type>`
+
+Return a flat structure of comments by specified Author for example `Author` with `ID: 1`
+
+**Example URL**: `https://localhost:1337/api/comments/author/1` - get comments by `ID:1` of Strapi User
+**Example URL**: `https://localhost:1337/api/comments/author/1/generic` - get comments by `ID:1` of Generic User
+
+**Example response body**
+
+```json
+{
+  "data": [
+    {
+      // -- Comment Model fields ---
+    },
+    {
+      // -- Comment Model fields ---
+    }
+    // ...
+  ],
+  "meta": {
+    "pagination": {
+      // payload based on Strapi REST Pagination specification
+    }
+  }
+}
+```
+
+**Possible response codes**
+
+- `200` - Successful. Response with list of comments (can be empty)
+- `400` - Bad Request. Requested list for not valid / not existing Content Type
+
+#### Strapi REST API properties support:
+
+- [filtering](https://docs.strapi.io/developer-docs/latest/developer-resources/database-apis-reference/rest/filtering-locale-publication.html#filtering)
+- [field selection](https://docs.strapi.io/developer-docs/latest/developer-resources/database-apis-reference/rest/populating-fields.html#field-selection)
+- [sorting](https://docs.strapi.io/developer-docs/latest/developer-resources/database-apis-reference/rest/sort-pagination.html#sorting)
+- [pagination](https://docs.strapi.io/developer-docs/latest/developer-resources/database-apis-reference/rest/sort-pagination.html#pagination)
+
 ### Post a Comment
 
 _GraphQL equivalent: [Public GraphQL API -> Post a Comments](#post-a-comment-1)_
@@ -534,57 +578,6 @@ _REST API equivalent: [Public REST API -> Get Comments](#get-comments)_
 
 ```graphql
 query {
-  findAllFlat(
-    relation: "api::page.page:1"
-    filters: { content: { contains: "Test" } }
-  ) {
-    id
-    content
-    blocked
-    threadOf {
-      id
-    }
-    author {
-      id
-      name
-    }
-  }
-}
-```
-
-**Example response**
-
-```json
-{
-  "data": {
-    "findAllFlat": [
-      {
-        "id": 3,
-        "content": "Test",
-        "blocked": false,
-        "threadOf": null,
-        "author": {
-          "id": "123456",
-          "name": "Joe Doe"
-        }
-      },
-      // ...
-    ]
-  }
-```
-
-#### Strapi GraphQL API properties support:
-
-- [sorting](https://docs.strapi.io/developer-docs/latest/developer-resources/database-apis-reference/graphql-api.html#sorting)
-
-### Get Comments (flat structure)
-
-_REST API equivalent: [Public REST API -> Get Comments (flat structure)](#get-comments-flat-structure)_
-
-**Example request**
-
-```graphql
-query {
   findAllInHierarchy(relation: "api::page.page:1") {
     id
     content
@@ -631,6 +624,106 @@ query {
     ]
   }
 }
+```
+
+#### Strapi GraphQL API properties support:
+
+- [sorting](https://docs.strapi.io/developer-docs/latest/developer-resources/database-apis-reference/graphql-api.html#sorting)
+
+### Get Comments (flat structure)
+
+_REST API equivalent: [Public REST API -> Get Comments (flat structure)](#get-comments-flat-structure)_
+
+**Example request**
+
+```graphql
+query {
+  findAllFlat(
+    relation: "api::page.page:1"
+    filters: { content: { contains: "Test" } }
+  ) {
+    id
+    content
+    blocked
+    threadOf {
+      id
+    }
+    author {
+      id
+      name
+    }
+  }
+}
+```
+
+**Example response**
+
+```json
+{
+  "data": {
+    "findAllFlat": [
+      {
+        "id": 3,
+        "content": "Test",
+        "blocked": false,
+        "threadOf": null,
+        "author": {
+          "id": "123456",
+          "name": "Joe Doe"
+        }
+      },
+      // ...
+    ]
+  }
+```
+
+#### Strapi GraphQL API properties support:
+
+- [filtering](https://docs.strapi.io/developer-docs/latest/developer-resources/database-apis-reference/graphql-api.html#filters)
+- [sorting](https://docs.strapi.io/developer-docs/latest/developer-resources/database-apis-reference/graphql-api.html#sorting)
+- [pagination](https://docs.strapi.io/developer-docs/latest/developer-resources/database-apis-reference/graphql-api.html#pagination)
+
+### Get Comments (by Author)
+
+_REST API equivalent: [Public REST API -> Get Comments (by Author)](#get-comments-by-author)_
+
+**Example request**
+
+```graphql
+query {
+  findAllPerAuthor(authorId: 1, authorType: STRAPI) { // authorType might be one of [GENERIC, STRAPI]
+    data {
+      id
+      content
+      blocked
+      threadOf {
+        id
+      }
+    }
+  }
+}
+
+```
+
+**Example response**
+
+```json
+{
+  "data": {
+    "findAllPerAuthor": {
+      "data": [
+        {
+          "id": 4,
+          "content": "Hackaton test comment",
+          "blocked": false,
+          "threadOf": {
+            "id": 1
+          }
+        }
+      // ...
+      ]
+    }
+  }
 ```
 
 #### Strapi GraphQL API properties support:

--- a/admin/src/index.ts
+++ b/admin/src/index.ts
@@ -72,14 +72,7 @@ export default {
     registerCustomFields(app);
   },
 
-  // bootstrap(app: ToBeFixed) {
-  //   // app.injectContentManagerComponent('editView', 'informations', {
-  //   //     name: 'comments-link',
-  //   //     Component: () => 'TODO: Comments count',
-  //   // });
-  // },
-
-  registerTrads({ locales }: { locales: Array<TranslationKey>}) {
+  registerTrads({ locales = [] }: { locales: Array<TranslationKey>}) {
     return locales.map((locale: string) => {
       return {
         data: prefixPluginTranslations(get<Translations, TranslationKey>(trads, locale as TranslationKey), pluginId, {}),

--- a/server/controllers/client.ts
+++ b/server/controllers/client.ts
@@ -21,6 +21,7 @@ import {
 import { parseParams, throwError } from "./utils/functions";
 import { flatInput } from "./utils/parsers";
 import PluginError from "../utils/error";
+import { AUTHOR_TYPE } from "../utils/constants";
 
 const controllers: IControllerClient = {
   getService(name = "client") {
@@ -80,6 +81,38 @@ const controllers: IControllerClient = {
           }),
           dropBlockedThreads: true,
         }
+      );
+    } catch (e: ToBeFixed) {
+      throw throwError(ctx, e);
+    }
+  },
+
+  async findAllPerAuthor(
+    this: IControllerClient,
+    ctx: StrapiRequestContext<never, ToBeFixed>
+  ): ThrowablePromisedResponse<StrapiPaginatedResponse<Comment>> {
+    const { params = {}, query, sort, pagination } = ctx;
+    const { id, type } = parseParams<{ id: Id, type: string }>(params);
+
+    const {
+      sort: querySort,
+      pagination: queryPagination,
+      fields,
+      ...filterQuery
+    } = query || {};
+
+    try {
+      assertParamsPresent<{ id: Id }>(params, ["id"]);
+
+      return this.getService<IServiceCommon>("common").findAllPerAuthor(
+        flatInput({
+          query: filterQuery,
+          sort: sort || querySort,
+          pagination: pagination || queryPagination,
+          fields,
+        }),
+        id,
+        ![AUTHOR_TYPE.GENERIC.toLowerCase(), AUTHOR_TYPE.GENERIC].includes(type)
       );
     } catch (e: ToBeFixed) {
       throw throwError(ctx, e);

--- a/server/graphql/queries/findAllPerAuthor.ts
+++ b/server/graphql/queries/findAllPerAuthor.ts
@@ -1,0 +1,62 @@
+import {
+  Id,
+  IServiceCommon,
+  IServiceGraphQL,
+  StrapiGraphQLContext,
+  ToBeFixed,
+} from "../../../types";
+
+import { isEmpty } from "lodash";
+import contentType from "../../../content-types/comment";
+import { flatInput } from "../../controllers/utils/parsers";
+import { getPluginService } from "../../utils/functions";
+import { AUTHOR_TYPE } from "../../utils/constants";
+
+type ResponseFindAllPerAuthorResolverProps = {
+  authorId: Id;
+  authorType: 'STRAPI' | 'GENERIC' | undefined;
+  filters: ToBeFixed;
+  sort: ToBeFixed;
+  pagination: ToBeFixed;
+};
+
+export = ({ strapi, nexus }: StrapiGraphQLContext) => {
+  const { nonNull, intArg, arg } = nexus;
+  const { service: getService } = strapi.plugin("graphql");
+  const { args } = getService("internals");
+  const {
+    naming: { getFiltersInputTypeName },
+  } = getService("utils");
+
+  return {
+    type: "ResponseFindAllPerAuthor",
+    args: {
+      authorId: nonNull(intArg()),
+      authorType: arg({ type: 'AuthorType' }),
+      filters: getFiltersInputTypeName(contentType),
+      pagination: args.PaginationArg,
+      sort: args.SortArg,
+    },
+    // @ts-ignore
+    async resolve(obj: Object, args: ResponseFindAllPerAuthorResolverProps) {
+      const { authorId, authorType, filters, sort, pagination } = args;
+      const isStrapiUser = authorType !== AUTHOR_TYPE.GENERIC;
+      return await getPluginService<IServiceCommon>("common").findAllPerAuthor(
+        flatInput({
+          query: getPluginService<IServiceGraphQL>(
+            "gql"
+          ).graphQLFiltersToStrapiQuery(filters, contentType),
+          sort,
+          pagination: pagination
+            ? {
+                ...pagination,
+                withCount: !isEmpty(pagination),
+              }
+            : undefined,
+        }),
+        authorId,
+        isStrapiUser
+      );
+    },
+  };
+};

--- a/server/graphql/queries/index.ts
+++ b/server/graphql/queries/index.ts
@@ -2,11 +2,13 @@ import { INexusType, StrapiGraphQLContext } from "../../../types";
 
 import findAllFlat from "./findAllFlat";
 import findAllInHierarchy from "./findAllInHierarchy";
+import findAllPerAuthor from "./findAllPerAuthor";
 
 export = (context: StrapiGraphQLContext) => {
   const queries = {
     findAllFlat,
     findAllInHierarchy,
+    findAllPerAuthor,
   };
 
   return context.nexus.extendType({

--- a/server/graphql/types/comment-author-type.ts
+++ b/server/graphql/types/comment-author-type.ts
@@ -1,0 +1,9 @@
+import { AUTHOR_TYPE } from '../../utils/constants';
+import { StrapiGraphQLContext } from '../../../types';
+
+export = ({ nexus }: StrapiGraphQLContext) =>
+  nexus.enumType({
+    name: 'AuthorType',
+    description: "User type which was the author of comment - Strapi built-in or generic",
+    members: Object.values(AUTHOR_TYPE),
+  });

--- a/server/graphql/types/index.ts
+++ b/server/graphql/types/index.ts
@@ -4,6 +4,7 @@ import Id from "./id";
 import Comment from "./comment";
 import CommentNested from "./comment-nested";
 import CommentAuthor from "./comment-author";
+import CommentAuthorType from "./comment-author-type";
 import CreateComment from "./create-comment";
 import CreateCommentAuthor from "./create-comment-author";
 import UpdateComment from "./update-comment";
@@ -15,12 +16,14 @@ import CreateReport from "./create-report";
 import ResponsePagination from "./response-pagination";
 import ResponseMeta from "./response-meta";
 import ResponseFindAll from "./response-find-all";
+import ResponseFindAllPerAuthor from "./response-find-all-per-author";
 
 const typesFactories = [
   Id,
   Comment,
   CommentNested,
   CommentAuthor,
+  CommentAuthorType,
   CreateComment,
   CreateCommentAuthor,
   UpdateComment,
@@ -32,6 +35,7 @@ const typesFactories = [
   ResponsePagination,
   ResponseMeta,
   ResponseFindAll,
+  ResponseFindAllPerAuthor,
 ];
 
 export = (context: StrapiGraphQLContext) =>

--- a/server/graphql/types/response-find-all-per-author.ts
+++ b/server/graphql/types/response-find-all-per-author.ts
@@ -1,0 +1,10 @@
+import { INexusType, StrapiGraphQLContext } from "../../../types";
+
+export = ({ nexus }: StrapiGraphQLContext) =>
+  nexus.objectType({
+    name: "ResponseFindAllPerAuthor",
+    definition(t: INexusType) {
+      t.list.field("data", { type: "CommentSingle" });
+      t.field("meta", { type: "ResponseMeta" });
+    },
+  });

--- a/server/routes/client.ts
+++ b/server/routes/client.ts
@@ -90,6 +90,36 @@ const routes: StrapiRoute[] = [
       },
     },
   },
+  {
+    method: "GET",
+    path: "/author/:id",
+    handler: "client.findAllPerAuthor",
+    config: {
+      policies: [],
+      description:
+        "Find all comments created by Strapi user",
+      tag: {
+        plugin: "comments",
+        name: "Comments",
+        actionType: "find",
+      },
+    },
+  },
+  {
+    method: "GET",
+    path: "/author/:id/:type",
+    handler: "client.findAllPerAuthor",
+    config: {
+      policies: [],
+      description:
+        "Find all comments created by specified type of user",
+      tag: {
+        plugin: "comments",
+        name: "Comments",
+        actionType: "find",
+      },
+    },
+  },
 ];
 
 export default routes;

--- a/server/services/__tests__/common.test.ts
+++ b/server/services/__tests__/common.test.ts
@@ -614,6 +614,176 @@ describe("Test Comments service - Common", () => {
       });
     });
 
+    describe("findAllPerAuthor", () => {
+      const authorId = 1;
+
+      describe("Generic author", () => {
+        let spy;
+
+        beforeEach(() => {
+          spy = jest
+            .spyOn(global.strapi.db, "query")
+              // @ts-ignore
+              .mockImplementation((type: string) => ({
+                findMany: async (_: any) => 
+                  new Promise((resolve) => {
+                    switch (type) {
+                      case "plugins::comments.comment":
+                        return resolve(db.filter(item => item.authorId === _.where.authorId));
+                      default:
+                        return resolve([relatedEntity]);
+                    }
+                  }),
+                findWithCount: async ({ where }: any) => 
+                  new Promise((resolve) => {
+                    switch (type) {
+                      case "plugins::comments.comment":
+                        const filteredDB = db.filter(item => (item.authorId === where.authorId) && (item.threadOf === where.threadOf));
+                        return resolve([filteredDB.length, filteredDB]);
+                      default:
+                        return resolve([1, relatedEntity]);
+                    }
+                  }),
+              }));
+        });
+
+        afterEach(() => {
+          spy.mockRestore();
+        });
+
+        test("Should return proper structure", async () => {
+          const result = await getPluginService<IServiceCommon>(
+            "common"
+          ).findAllPerAuthor({ }, authorId);
+          expect(result).toHaveProperty("data");
+          expect(result).not.toHaveProperty("meta");
+          expect(result.data.length).toBe(3);
+          expect(result).not.toHaveProperty(["data", 0, "author"]);
+          expect(result).not.toHaveProperty(["data", 1, "author"]);
+          expect(result).not.toHaveProperty(["data", 2, "author"]);
+          expect(result).toHaveProperty(["data", 0, "content"], db[0].content);
+          expect(result).toHaveProperty(["data", 2, "content"], db[2].content);
+        });
+
+        test("Should return structure with selected fields only (+mandatory ones for logic)", async () => {
+          // Default fields are: id, related, threadOf, gotThread
+          const result = await getPluginService<IServiceCommon>(
+            "common"
+          ).findAllPerAuthor(
+            { fields: ["content"] },
+            authorId
+          );
+          expect(result).toHaveProperty("data");
+          expect(result).not.toHaveProperty("meta");
+          expect(result.data.length).toBe(3);
+          expect(result).not.toHaveProperty(["data", 0, "author"]);
+          expect(result).not.toHaveProperty(["data", 1, "author"]);
+          expect(result).not.toHaveProperty(["data", 2, "author"]);
+          expect(Object.keys(filterOutUndefined(result.data[0]))).toHaveLength(5);
+          expect(Object.keys(filterOutUndefined(result.data[1]))).toHaveLength(6);
+          expect(Object.keys(filterOutUndefined(result.data[2]))).toHaveLength(5);
+        });
+  
+        test("Should return structure with pagination", async () => {
+          const result = await getPluginService<IServiceCommon>(
+            "common"
+          ).findAllPerAuthor(
+            { pagination: { page: 1, pageSize: 5 } },
+            authorId
+          );
+          expect(result).toHaveProperty("data");
+          expect(result).toHaveProperty("meta");
+          expect(result.data.length).toBe(3);
+          expect(result).toHaveProperty(["data", 0, "content"], db[0].content);
+          expect(result).toHaveProperty(["data", 2, "content"], db[2].content);
+          expect(result).not.toHaveProperty(["data", 0, "author"]);
+          expect(result).not.toHaveProperty(["data", 1, "author"]);
+          expect(result).not.toHaveProperty(["data", 2, "author"]);
+          expect(result).toHaveProperty(["meta", "pagination", "page"], 1);
+          expect(result).toHaveProperty(["meta", "pagination", "pageSize"], 5);
+        });
+      });
+
+      describe("Strapi author", () => {
+        let spy;
+
+        beforeEach(() => {
+          spy = jest
+            .spyOn(global.strapi.db, "query")
+              // @ts-ignore
+              .mockImplementation((type: string) => ({
+                findMany: async (_: any) => 
+                  new Promise((resolve) => {
+                    switch (type) {
+                      case "plugins::comments.comment":
+                        return resolve(db.filter(item => item?.authorUser?.id === _.where?.authorUser?.id));
+                      default:
+                        return resolve([relatedEntity]);
+                    }
+                  }),
+                findWithCount: async ({ where }: any) => 
+                  new Promise((resolve) => {
+                    switch (type) {
+                      case "plugins::comments.comment":
+                        const filteredDB = db.filter(item => (item?.authorUser?.id === where?.authorUser?.id) && (item.threadOf === where.threadOf));
+                        return resolve([filteredDB.length, filteredDB]);
+                      default:
+                        return resolve([1, relatedEntity]);
+                    }
+                  }),
+              }));
+        });
+
+        afterEach(() => {
+          spy.mockRestore();
+        });
+
+        test("Should return proper structure", async () => {
+          const result = await getPluginService<IServiceCommon>(
+            "common"
+          ).findAllPerAuthor({ }, authorId, true);
+          expect(result).toHaveProperty("data");
+          expect(result).not.toHaveProperty("meta");
+          expect(result.data.length).toBe(1);
+          expect(result).not.toHaveProperty(["data", 0, "author"]);
+          expect(result).toHaveProperty(["data", 0, "content"], db[3].content);
+        });
+
+        test("Should return structure with selected fields only (+mandatory ones for logic)", async () => {
+          // Default fields are: id, related, threadOf, gotThread
+          const result = await getPluginService<IServiceCommon>(
+            "common"
+          ).findAllPerAuthor(
+            { fields: ["content"] },
+            authorId,
+            true
+          );
+          expect(result).toHaveProperty("data");
+          expect(result).not.toHaveProperty("meta");
+          expect(result.data.length).toBe(1);
+          expect(result).not.toHaveProperty(["data", 0, "author"]);
+          expect(Object.keys(filterOutUndefined(result.data[0]))).toHaveLength(5);
+        });
+  
+        test("Should return structure with pagination", async () => {
+          const result = await getPluginService<IServiceCommon>(
+            "common"
+          ).findAllPerAuthor(
+            { pagination: { page: 1, pageSize: 5 } },
+            authorId,
+            true
+          );
+          expect(result).toHaveProperty("data");
+          expect(result).toHaveProperty("meta");
+          expect(result.data.length).toBe(1);
+          expect(result).toHaveProperty(["data", 0, "content"], db[3].content);
+          expect(result).not.toHaveProperty(["data", 0, "author"]);
+          expect(result).toHaveProperty(["meta", "pagination", "page"], 1);
+          expect(result).toHaveProperty(["meta", "pagination", "pageSize"], 5);
+        });
+      });
+    });
+
     describe("findOne", () => {
       test("Should return proper structure", async () => {
         const result = await getPluginService<IServiceCommon>("common").findOne(

--- a/server/services/common.ts
+++ b/server/services/common.ts
@@ -8,15 +8,12 @@ import {
   isEmpty,
   first,
   parseInt,
-  set,
   get,
-  uniq,
 } from "lodash";
 import {
   Id,
   StrapiContext,
   StrapiStore,
-  StrapiPagination,
   StrapiResponseMeta,
   StrapiPaginatedResponse,
   StrapiDBQueryArgs,
@@ -36,7 +33,7 @@ import {
   CommentModelKeys,
   SettingsCommentsPluginConfig,
 } from "../../types";
-import { REGEX, CONFIG_PARAMS } from "../utils/constants";
+import { CONFIG_PARAMS } from "../utils/constants";
 import PluginError from "./../utils/error";
 import {
   getModelUid,
@@ -46,6 +43,11 @@ import {
   buildAuthorModel,
   buildConfigQueryProp,
 } from "./utils/functions";
+import { 
+  parseFieldsQuery,
+  parsePaginationsQuery,
+  parseSortQuery
+} from "./utils/parsers";
 
 /**
  * Comments Plugin - common services
@@ -112,69 +114,9 @@ export = ({ strapi }: StrapiContext): IServiceCommon => ({
         Array<string>
       >(CONFIG_PARAMS.AUTHOR_BLOCKED_PROPS, []);
 
-    let queryExtension: StrapiDBQueryArgs<CommentModelKeys> = {};
-
-    if (sort && (isString(sort) || isArray(sort))) {
-      queryExtension = {
-        ...queryExtension,
-        orderBy: (isString(sort) ? [sort] : sort)
-          .map((_) => (REGEX.sorting.test(_) ? _ : `${_}:asc`))
-          .reduce((prev, curr) => {
-            const [type = "asc", ...parts] = curr.split(":").reverse();
-            return { ...set(prev, parts.reverse().join("."), type) };
-          }, {}),
-      };
-    }
-
-    if (!isNil(fields)) {
-      queryExtension = {
-        ...queryExtension,
-        select: isArray(fields) ? uniq([...fields, ...defaultSelect]) : fields,
-      };
-    }
-
-    let meta: StrapiResponseMeta = {} as StrapiResponseMeta;
-    if (pagination && isObject(pagination)) {
-      const parsedpagination: StrapiPagination = Object.keys(pagination).reduce(
-        (prev: StrapiPagination, curr: string) => ({
-          ...prev,
-          [curr]: parseInt(get(pagination, curr)),
-        }),
-        {}
-      );
-      const {
-        page = 1,
-        pageSize = PAGE_SIZE,
-        start = 0,
-        limit = PAGE_SIZE,
-      } = parsedpagination;
-      const paginationByPage =
-        !isNil(parsedpagination?.page) || !isNil(parsedpagination?.pageSize);
-
-      queryExtension = {
-        ...queryExtension,
-        offset: paginationByPage ? (page - 1) * pageSize : start,
-        limit: paginationByPage ? pageSize : limit,
-      };
-
-      const metapagination = paginationByPage
-        ? {
-            pagination: {
-              page,
-              pageSize,
-            },
-          }
-        : {
-            pagination: {
-              start,
-              limit,
-            },
-          };
-
-      meta = {
-        ...metapagination,
-      };
-    }
+    const sortQuery = parseSortQuery(sort);
+    const fieldsQuery = parseFieldsQuery(fields, sortQuery, defaultSelect);
+    let [meta, queryExtension = {}]: [StrapiResponseMeta, StrapiDBQueryArgs<CommentModelKeys>] = parsePaginationsQuery(pagination, fieldsQuery, { PAGE_SIZE });
 
     const entries = await strapi.db
       .query<Comment>(getModelUid("comment"))
@@ -339,8 +281,51 @@ export = ({ strapi }: StrapiContext): IServiceCommon => ({
     return filterOurResolvedReports(this.sanitizeCommentEntity(entity, doNotPopulateAuthor));
   },
 
-  // Find all related entiries
+  // Find all for author
+  async findAllPerAuthor(
+    this: IServiceCommon,
+    {
+      query = {},
+      populate = {},
+      pagination,
+      sort,
+      fields,
+      isAdmin = false,
+    }: FindAllFlatProps<Comment>,
+    authorId: Id,
+    isStrapiAuthor: boolean = false,
+  ): Promise<StrapiPaginatedResponse<Comment>> {
+    if (isNil(authorId)) {
+      return {
+        data: [],
+      };
+    }
 
+    const { related, ...restQuery } = query;
+
+    const authorQuery = isStrapiAuthor ? {
+      authorUser: {
+        id: authorId
+      },
+    } : {
+      authorId,
+    };
+
+    const response = await this.findAllFlat({ 
+      query: {
+        ...restQuery,
+        ...authorQuery,
+      },
+      pagination, populate, sort, fields, isAdmin 
+    });
+
+    return {
+      ...response,
+      data: response.data.map(({ author, ...rest }: Comment): Comment => rest),
+    };
+  },
+
+  // Find all related entiries
   async findRelatedEntitiesFor(
     entities: Array<Comment> = []
   ): Promise<Array<RelatedEntity>> {

--- a/server/services/utils/__tests__/parsers.test.js
+++ b/server/services/utils/__tests__/parsers.test.js
@@ -1,0 +1,113 @@
+const { setupStrapi, resetStrapi } = require("../../../../__mocks__/initSetup");
+const PluginError = require("../../../utils/error");
+const {
+  parseSortQuery,
+  parseFieldsQuery,
+  parsePaginationsQuery,
+} = require("../parsers");
+
+beforeEach(setupStrapi);
+afterEach(resetStrapi);
+
+describe("Test service parse utils", () => {
+  describe("Sort", () => {
+    const query = {
+      where: {
+        related: 1,
+      },
+    };
+
+    test("Should parse single sort", () => {
+      const result = parseSortQuery("id:asc", query);
+      expect(result).toHaveProperty(["orderBy", "id"], "asc");
+      expect(result).toHaveProperty(["where", "related"], query.where.related);
+    });
+
+    test("Should parse multiple sort", () => {
+      const result = parseSortQuery(["id:asc", "threadOf:desc"], query);
+      expect(Object.keys(result.orderBy).length).toBe(2);
+      expect(result).toHaveProperty(["orderBy", "id"], "asc");
+      expect(result).toHaveProperty(["orderBy", "threadOf"], "desc");
+      expect(result).toHaveProperty(["where", "related"], query.where.related);
+    });
+  });
+
+  describe("Fields", () => {
+    const query = {
+      where: {
+        related: 1,
+      },
+    };
+
+    test("Should parse default fields", () => {
+      const result = parseFieldsQuery([], query, ["id", "related"]);
+      expect(result).toHaveProperty("select");
+      expect(result.select.length).toBe(2);
+      expect(result.select.includes("id")).toBe(true);
+      expect(result.select.includes("related")).toBe(true);
+      expect(result).toHaveProperty(["where", "related"], query.where.related);
+    });
+
+    test("Should parse selected fields with defaults", () => {
+      const result = parseFieldsQuery(["content"], query, ["id", "related"]);
+      expect(result).toHaveProperty("select");
+      expect(result.select.length).toBe(3);
+      expect(result.select.includes("id")).toBe(true);
+      expect(result.select.includes("related")).toBe(true);
+      expect(result.select.includes("content")).toBe(true);
+      expect(result).toHaveProperty(["where", "related"], query.where.related);
+    });
+
+    test("Should parse selected fields with defaults and without duplicates", () => {
+      const result = parseFieldsQuery(["id", "content"], query, ["id", "related"]);
+      expect(result).toHaveProperty("select");
+      expect(result.select.length).toBe(3);
+      expect(result.select.includes("id")).toBe(true);
+      expect(result.select.includes("related")).toBe(true);
+      expect(result.select.includes("content")).toBe(true);
+      expect(result).toHaveProperty(["where", "related"], query.where.related);
+    });
+  });
+
+  describe("Pagination", () => {
+    const query = {
+      where: {
+        related: 1,
+      },
+    };
+
+    test("Should parse with defaults", () => {
+      const result = parsePaginationsQuery({
+        page: "2",
+      }, query, { PAGE_SIZE: 10 });
+
+      expect(result.length).toBe(2);
+
+      const [meta, extendedQuery] = result;
+      
+      expect(meta).toHaveProperty("pagination");
+      expect(meta).toHaveProperty("pagination", "page", 2);
+      expect(meta).toHaveProperty("pagination", "pageSize", 10);
+      expect(extendedQuery).toHaveProperty(["limit"], 10);
+      expect(extendedQuery).toHaveProperty(["offset"], 10);
+      expect(extendedQuery).toHaveProperty(["where", "related"], query.where.related);
+    });
+
+    test("Should parse with defaults overwritten", () => {
+      const result = parsePaginationsQuery({
+        page: "4",
+        pageSize: "5",
+      }, query, { PAGE_SIZE: 10 });
+
+      expect(result.length).toBe(2);
+
+      const [meta, extendedQuery] = result;
+      expect(meta).toHaveProperty("pagination");
+      expect(meta).toHaveProperty("pagination", "page", 3);
+      expect(meta).toHaveProperty("pagination", "pageSize", 5);
+      expect(extendedQuery).toHaveProperty(["limit"], 5);
+      expect(extendedQuery).toHaveProperty(["offset"], 15);
+      expect(extendedQuery).toHaveProperty(["where", "related"], query.where.related);
+    });
+  });
+});

--- a/server/services/utils/functions.ts
+++ b/server/services/utils/functions.ts
@@ -156,7 +156,7 @@ export const resolveUserContextError = (user: StrapiUser): PluginError => {
   }
 };
 
-export const getAuthorName = (author: StrapiAdmin) =>{
+export const getAuthorName = (author: StrapiAdmin) => {
   
   const {lastname, username, firstname} = author;
 

--- a/server/services/utils/parsers.ts
+++ b/server/services/utils/parsers.ts
@@ -1,0 +1,83 @@
+import { StrapiDBQueryArgs, StrapiPagination, StrapiResponseMeta, StringMap } from "strapi-typed";
+import { CommentModelKeys, ToBeFixed } from "../../../types";
+import { REGEX } from "./../../utils/constants";
+import { get, set, uniq, isArray, isObject, isString, isNil } from "lodash";
+
+export const parseSortQuery = (
+    sort: StringMap<unknown> | undefined, 
+    query: StrapiDBQueryArgs<CommentModelKeys> = {}
+): StrapiDBQueryArgs<CommentModelKeys> => {
+    if (sort && (isString(sort) || isArray(sort))) {
+      return {
+        ...query,
+        orderBy: (isString(sort) ? [sort] : sort)
+          .map((_: string) => (REGEX.sorting.test(_) ? _ : `${_}:asc`))
+          .reduce((prev: Object, curr: string) => {
+            const [type = "asc", ...parts] = curr.split(":").reverse();
+            return { ...set(prev, parts.reverse().join("."), type) };
+          }, {}) as ToBeFixed,
+      };
+    }
+    return query;
+};
+
+export const parseFieldsQuery = (
+    fields: ToBeFixed, 
+    query: StrapiDBQueryArgs<CommentModelKeys> = {},
+    defaultSelect: Array<CommentModelKeys> = []
+): StrapiDBQueryArgs<CommentModelKeys> => {
+    if (!isNil(fields)) {
+        return {
+          ...query,
+          select: isArray(fields) ? uniq([...fields, ...defaultSelect]) : fields,
+        };
+      }
+    return query;
+};
+
+export const parsePaginationsQuery = (
+    pagination: StrapiPagination | undefined, 
+    query: StrapiDBQueryArgs<CommentModelKeys> = {},
+    defaults: any = []
+): [StrapiResponseMeta, StrapiDBQueryArgs<CommentModelKeys>] => {
+    if (pagination && isObject(pagination)) {
+        const parsedpagination: StrapiPagination = Object.keys(pagination).reduce(
+          (prev: StrapiPagination, curr: string) => ({
+            ...prev,
+            [curr]: parseInt(get(pagination, curr)),
+          }),
+          {}
+        );
+        const {
+          page = 1,
+          pageSize = defaults.PAGE_SIZE,
+          start = 0,
+          limit = defaults.PAGE_SIZE,
+        } = parsedpagination;
+        const paginationByPage =
+          !isNil(parsedpagination?.page) || !isNil(parsedpagination?.pageSize);
+  
+        const metapagination = paginationByPage
+          ? {
+              pagination: {
+                page,
+                pageSize,
+              },
+            }
+          : {
+              pagination: {
+                start,
+                limit,
+              },
+            };
+  
+        return [{
+          ...metapagination,
+        }, {
+            ...query,
+            offset: paginationByPage ? (page - 1) * pageSize : start,
+            limit: paginationByPage ? pageSize : limit,
+        }];
+      }
+    return [{} as StrapiResponseMeta, query];
+}

--- a/server/utils/constants.ts
+++ b/server/utils/constants.ts
@@ -15,6 +15,11 @@ export const APPROVAL_STATUS = {
   REJECTED: "REJECTED",
 };
 
+export const AUTHOR_TYPE = {
+  GENERIC: 'GENERIC',
+  STRAPI: 'STRAPI',
+};
+
 export const REGEX: RegExpCollection = {
   uid: /^(?<type>[a-z0-9-]+)\:{2}(?<api>[a-z0-9-]+)\.{1}(?<contentType>[a-z0-9-]+)$/i,
   relatedUid:

--- a/types/controllers.d.ts
+++ b/types/controllers.d.ts
@@ -38,9 +38,9 @@ import {
 } from "./services";
 
 export type FlatInput<TKeys extends string> = {
-  relation: Id;
   query: ToBeFixed;
   sort: ToBeFixed;
+  relation?: Id;
   pagination?: ToBeFixed;
   fields?: StrapiRequestQueryFieldsClause<TKeys>;
 };
@@ -127,6 +127,9 @@ export interface IControllerClient {
   findAllInHierarchy(
     ctx: StrapiRequestContext<never>
   ): ThrowablePromisedResponse<Array<Comment>>;
+  findAllPerAuthor(
+    ctx: StrapiRequestContext<never>
+  ): ThrowablePromisedResponse<StrapiPaginatedResponse<Comment>>;
   post(
     ctx: StrapiRequestContext<CreateCommentPayload>
   ): ThrowablePromisedResponse<Comment>;

--- a/types/services.d.ts
+++ b/types/services.d.ts
@@ -87,6 +87,11 @@ export interface IServiceCommon {
     relatedEntity?: RelatedEntity | null | boolean
   ): Promise<Array<Comment>>;
   findOne(criteria: WhereClause): Promise<Comment>;
+  findAllPerAuthor(
+    props: FindAllFlatProps<Comment>,
+    authorId: Id,
+    isStrapiAuthor?: boolean
+  ): Promise<StrapiPaginatedResponse<Comment>>;
   findRelatedEntitiesFor(entities: Array<Comment>): Promise<RelatedEntity[]>;
   mergeRelatedEntityTo(
     entity: ToBeFixed,


### PR DESCRIPTION
## Ticket

https://github.com/VirtusLab/strapi-plugin-comments/issues/209

## Summary

What does this PR do/solve?

Provides ability to filter by `author` for generic & strapi users
- `/api/comments/author/:id` - Strapi users
- `/api/comments/author/:id/generic` - Generic users

## Test Plan

1. Run you projects with some comments created
2. Run queries against endpoints:
   - `/api/comments/author/:id` - Strapi users
   - `/api/comments/author/:id/generic` - Generic users
3. You should get comments authored by specific user with `related` entity attached
