### PR TITLE
Fixed behavior when no enabled collections are configured.

### DIFF
--- a/server/services/client.ts
+++ b/server/services/client.ts
@@ -51,9 +51,12 @@ export = ({ strapi }: StrapiContext): IServiceClient => ({
       relation
     );
 
+    const enabledCollections: Array<string> = await this.getCommonService().getConfig<
+      Array<string>
+    >(CONFIG_PARAMS.ENABLED_COLLECTIONS, []);
     const isEnabledCollection =
       await this.getCommonService().isEnabledCollection(uid);
-    if (!isEnabledCollection) {
+    if (enabledCollections.length > 0 && !isEnabledCollection) {
       throw new PluginError(
         400,
         `Field "related" refer to not enabled collection. Please amend the plugin settings and try again`

--- a/server/services/common.ts
+++ b/server/services/common.ts
@@ -453,7 +453,7 @@ export = ({ strapi }: StrapiContext): IServiceCommon => ({
       Array<string>
     >(CONFIG_PARAMS.ENABLED_COLLECTIONS, []);
 
-    if (!isEnabledCollection) {
+    if (enabledCollections.length > 0 && !isEnabledCollection) {
       throw new PluginError(
         403,
         `Action not allowed for collection '${uid}'. Use one of: ${enabledCollections.join(


### PR DESCRIPTION
All collection types should allow comments when no enabled collection types are set.

![StrapiCommentsConfigurationPage](https://github.com/VirtusLab-Open-Source/strapi-plugin-comments/assets/27326587/d462de30-d39b-4c40-9bd0-95bb8111c231)

## Ticket
Configuration Page

## Summary

This PR fixes the behavior of the "Enable comments only for" setting in the Comments plugin configuration. The tooltip underneath the setting states that "If none is selected, all the content types are enabled" however, in production when no content types are selected then no content types are enabled. 

## Test Plan

This fix was tested with two Content Types: Post and Writer. 

Before Fix: 
1. Enable no content types
2. Try to add comment to Post - Does not Comment
3. Try to add comment to Writer - Does not Comment
4. Enable Post in settings
5. Try to add comment on Post - Correctly adds comment
6. Try to add comment on Writer - Correctly does not add comment

After Fix: 
1. Enable no content types
2. Try to add comment to Post - Adds Comment
3. Try to add comment to Writer - Adds Comment
4. Enable Post in settings
5. Try to add comment on Post - Correctly adds comment
6. Try to add comment on Writer - Correctly does not add comment
