### PR TITLE
feat: lifecycle hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -931,6 +931,46 @@ For developers who upgrades their Strapi instance custom field from Comments plu
 
 Read more about this feature in [Strapi's docs](https://docs-next.strapi.io/user-docs/latest/plugins/introduction-to-plugins.html#custom-fields).
 
+## Model lifecycle hooks
+
+Comments plugin allows to register lifecycle hooks for `Comment` and `Comment report` content types.
+
+You can read more about lifecycle hooks [here](https://docs.strapi.io/dev-docs/backend-customization/models#lifecycle-hooks). (You can set a listener for all of the hooks).
+
+Lifecycle hooks can be register either in `register()` or `bootstrap()` methods of your server. You can register more than one listener for a specified lifecycle hook. For example: you want to do three things on report creation and do not want to handle all of these actions in one big function. You can split logic in as many listeners as you want.
+
+Listeners can by sync and `async`.
+
+>Be aware that lifecycle hooks registered in `register()` may be fired by plugin's bootstrapping. If you want listen to events triggered after server's startup use `bootstrap()`.
+
+Example:
+
+```ts
+  const commentsCommonService = strapi
+    .plugin("comments")
+    .service("common");
+
+  commentsCommonService.registerLifecycleHook({
+    callback: async ({ action, result }) => {
+      const saveResult = await logIntoSystem(action, result);
+
+      console.log(saveResult);
+    },
+    contentTypeName: "comment",
+    hookName: "afterCreate",
+  });
+
+  commentsCommonService.registerLifecycleHook({
+    callback: async ({ action, result }) => {
+      const saveResult = await logIntoSystem(action, result);
+
+      console.log(saveResult);
+    },
+    contentTypeName: "report",
+    hookName: "afterCreate",
+  });
+```
+
 ## 🤝 Contributing
 
 <div>

--- a/content-types/index.ts
+++ b/content-types/index.ts
@@ -1,11 +1,19 @@
+import { StrapiContext } from "strapi-typed";
+import { buildAllHookListeners } from "../server/utils/functions";
 import CommentCT from "./comment";
 import ReportCT from "./report";
 
 export default {
   comment: {
     schema: CommentCT,
+    lifecycles: buildAllHookListeners("comment", {
+      strapi,
+    } as unknown as StrapiContext),
   },
   "comment-report": {
     schema: ReportCT,
+    lifecycles: buildAllHookListeners("comment-report", {
+      strapi,
+    } as unknown as StrapiContext),
   },
 };

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "clean": "rm -rf build",
     "develop": "nodemon --exec \"yarn build:dev\"",
     "test:unit": "jest --verbose --coverage",
+    "test:watch": "jest --verbose --watch",
     "test:unit:ci": "CI=true jest --ci --runInBand --verbose --coverage",
     "lint": "prettier --check .",
     "format": "prettier --write ."

--- a/server/services/__tests__/common.test.ts
+++ b/server/services/__tests__/common.test.ts
@@ -1,7 +1,7 @@
-import { IServiceCommon } from "../../../types";
+import { IServiceCommon, ToBeFixed } from "../../../types";
 import { Comment } from "../../../types/contentTypes";
 import { setupStrapi, resetStrapi } from "../../../__mocks__/initSetup";
-import { CONFIG_PARAMS } from "../../utils/constants";
+import { CONFIG_PARAMS, LIFECYCLE_HOOKS } from "../../utils/constants";
 import PluginError from "../../utils/error";
 import { getPluginService } from "../../utils/functions";
 
@@ -806,6 +806,41 @@ describe("Test Comments service - Common", () => {
         expect(result).toHaveProperty([0, "title"], relatedEntity.title);
         expect(result).toHaveProperty([0, "uid"], relatedEntity.uid);
       });
+    });
+
+    describe("Lifecycle hooks", () => {
+      it.each(LIFECYCLE_HOOKS)(
+        "should trigger for %s hook listener",
+        async (hookName: ToBeFixed) => {
+          // Given
+          const commonService = getPluginService<IServiceCommon>("common");
+          const listenerA = jest.fn().mockResolvedValue("ABC");
+          const listenerB = jest.fn();
+          const event = {} as ToBeFixed;
+
+          commonService.registerLifecycleHook({
+            callback: listenerA,
+            contentTypeName: "comment",
+            hookName,
+          });
+          commonService.registerLifecycleHook({
+            callback: listenerB,
+            contentTypeName: "comment",
+            hookName,
+          });
+
+          // When
+          await commonService.runLifecycleHook({
+            contentTypeName: "comment",
+            event,
+            hookName,
+          });
+
+          // Then
+          expect(listenerA).toHaveBeenCalledTimes(1);
+          expect(listenerB).toHaveBeenCalledTimes(1);
+        }
+      );
     });
   });
 });

--- a/server/utils/__tests__/functions.test.ts
+++ b/server/utils/__tests__/functions.test.ts
@@ -1,10 +1,15 @@
+import { StrapiContext } from "strapi-typed";
 import { setupStrapi, resetStrapi } from "../../../__mocks__/initSetup";
 import {
   assertNotEmpty,
   assertParamsPresent,
+  buildAllHookListeners,
+  buildHookListener,
   getPluginService,
   parseParams,
 } from "../functions";
+import { ContentType, LifeCycleEvent, LifeCycleHookName } from "../types";
+import { IServiceCommon, ToBeFixed } from "../../../types";
 
 beforeEach(setupStrapi);
 afterEach(resetStrapi);
@@ -48,6 +53,79 @@ describe("Test plugin functions utils", () => {
       expect(() => assertNotEmpty(0)).toThrow();
       expect(() => assertNotEmpty(1)).not.toThrow();
       expect(() => assertNotEmpty({ id: 1 })).not.toThrow();
+    });
+  });
+  describe("buildAllHookListeners()", () => {
+    it("should define a listener for each available model lifecycle hook", () => {
+      // Then
+      expect(buildAllHookListeners("comment", {} as StrapiContext))
+        .toMatchInlineSnapshot(`
+        {
+          "afterCount": [Function],
+          "afterCreate": [Function],
+          "afterCreateMany": [Function],
+          "afterDelete": [Function],
+          "afterDeleteMany": [Function],
+          "afterFindMany": [Function],
+          "afterFindOne": [Function],
+          "afterUpdate": [Function],
+          "afterUpdateMany": [Function],
+          "beforeCount": [Function],
+          "beforeCreate": [Function],
+          "beforeCreateMany": [Function],
+          "beforeDelete": [Function],
+          "beforeDeleteMany": [Function],
+          "beforeFindMany": [Function],
+          "beforeFindOne": [Function],
+          "beforeUpdate": [Function],
+          "beforeUpdateMany": [Function],
+        }
+      `);
+    });
+  });
+
+  describe("buildHookListener()", () => {
+    it("should delegate lifecycle hook event to defined listeners", async () => {
+      // Given
+      const contentTypeName: ContentType = "comment";
+      const service: Partial<IServiceCommon> = {
+        runLifecycleHook: jest.fn(),
+      };
+      const plugin: ToBeFixed = {
+        service() {
+          return service;
+        },
+      };
+      const context: StrapiContext = {
+        strapi: {
+          plugin() {
+            return plugin;
+          },
+        } as unknown as StrapiContext["strapi"],
+      };
+      const hookName: LifeCycleHookName = "afterCreate";
+      const event: Partial<LifeCycleEvent> = {
+        action: hookName,
+        model: {
+          attributes: {
+            name: "name",
+          },
+        } as unknown as LifeCycleEvent["model"],
+      };
+      const [, listener] = buildHookListener(
+        contentTypeName,
+        context
+      )(hookName);
+
+      // When
+      await listener(event as LifeCycleEvent);
+
+      // Then
+      expect(service.runLifecycleHook).toHaveBeenCalledWith({
+        contentTypeName,
+        hookName,
+        event,
+      });
     });
   });
 });

--- a/server/utils/constants.ts
+++ b/server/utils/constants.ts
@@ -1,4 +1,5 @@
 import { ConfigParamKeys, RegExpCollection } from "../../types";
+import { LifeCycleHookName } from "./types";
 
 export const CONFIG_PARAMS: ConfigParamKeys = {
   ENABLED_COLLECTIONS: "enabledCollections",
@@ -27,3 +28,24 @@ export const REGEX: RegExpCollection = {
   email: /\S+@\S+\.\S+/,
   sorting: /^(?<path>[a-z0-9-_\:\.]+)\:+(asc|desc)$/i,
 };
+
+export const LIFECYCLE_HOOKS: ReadonlyArray<LifeCycleHookName> = [
+  "beforeCreate",
+  "beforeCreateMany",
+  "afterCreate",
+  "afterCreateMany",
+  "beforeUpdate",
+  "beforeUpdateMany",
+  "afterUpdate",
+  "afterUpdateMany",
+  "beforeDelete",
+  "beforeDeleteMany",
+  "afterDelete",
+  "afterDeleteMany",
+  "beforeCount",
+  "afterCount",
+  "beforeFindOne",
+  "afterFindOne",
+  "beforeFindMany",
+  "afterFindMany",
+] as const;

--- a/server/utils/types.ts
+++ b/server/utils/types.ts
@@ -1,0 +1,47 @@
+import { Effect } from "../../types/utils";
+
+export type ContentType = "comment" | "comment-report";
+
+export type LifeCycleHookName =
+  | "beforeCreate"
+  | "beforeCreateMany"
+  | "afterCreate"
+  | "afterCreateMany"
+  | "beforeUpdate"
+  | "beforeUpdateMany"
+  | "afterUpdate"
+  | "afterUpdateMany"
+  | "beforeDelete"
+  | "beforeDeleteMany"
+  | "afterDelete"
+  | "afterDeleteMany"
+  | "beforeCount"
+  | "afterCount"
+  | "beforeFindOne"
+  | "afterFindOne"
+  | "beforeFindMany"
+  | "afterFindMany";
+
+export interface LifeCycleEvent<
+  THookName extends LifeCycleHookName = LifeCycleHookName,
+  TResult = unknown,
+  TParams = Record<string, unknown>
+> {
+  action: THookName;
+  model: {
+    singularName: string;
+    uid: string;
+    tableName: string;
+    attributes: Record<string, unknown>;
+    lifecycles: Partial<Record<LifeCycleHookName, Effect<LifeCycleEvent>>>;
+    indexes: Array<{
+      type?: string;
+      name: string;
+      columns: string[];
+    }>;
+    columnToAttribute: Record<string, string>;
+  };
+  state: Record<string, unknown>;
+  params: TParams;
+  result?: TResult | TResult[];
+}

--- a/types/services.d.ts
+++ b/types/services.d.ts
@@ -28,6 +28,7 @@ import {
 import { Comment, CommentReport, RelatedEntity } from "./contentTypes";
 
 import PluginError from "../server/utils/error";
+import { ContentType, LifeCycleEvent, LifeCycleHookName } from "../server/utils/types";
 
 export type AdminPaginatedResponse<T> = {
   result: Array<T>;
@@ -113,6 +114,8 @@ export interface IServiceCommon {
   ): Promise<[uid: string, relatedId: string | number]>;
   checkBadWords(content: string): Promise<boolean | string | PluginError>;
   isEnabledCollection(uid: string): Promise<boolean>;
+  registerLifecycleHook(input: { hookName: LifeCycleHookName, callback: Effect<LifeCycleEvent>, contentTypeName: ContentType }): void;
+  runLifecycleHook(input: { hookName: LifeCycleHookName, event: LifeCycleEvent, contentTypeName: ContentType }): Promise<void>;
 }
 
 export interface IServiceAdmin {


### PR DESCRIPTION
## Ticket

https://github.com/VirtusLab-Open-Source/strapi-plugin-comments/issues/202

## Summary

What does this PR do/solve?

- adding lifecycle hooks to comments content types

## Test Plan

- register lifecycle hooks (see README.md)
- start a server
- trigger lifecycle action (`afterCreate` for example)
- observe results
- lifecycle event should be triggered