### PR TITLE
feat: CU-86934hnmg rest api skipping fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -372,6 +372,12 @@ Return a flat structure of comments by specified Author for example `Author` wit
 **Example URL**: `https://localhost:1337/api/comments/author/1` - get comments by `ID:1` of Strapi User
 **Example URL**: `https://localhost:1337/api/comments/author/1/generic` - get comments by `ID:1` of Generic User
 
+#### Skipping fields
+
+To skip a field from the response you can use a query param called `omit`. It is a list of `Comment` entity fields you want to ignore. For example `?omit[]=author&omit[]=related`.
+
+**Remember!** `id` field is required so it will not be skipped.
+
 **Example response body**
 
 ```json

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "clean": "rm -rf build",
     "develop": "nodemon --exec \"yarn build:dev\"",
     "test:unit": "jest --verbose --coverage",
-    "test:watch": "jest --verbose --watch",
+    "test:unit:watch": "jest --verbose --watch",
     "test:unit:ci": "CI=true jest --ci --runInBand --verbose --coverage",
     "lint": "prettier --check .",
     "format": "prettier --write ."

--- a/server/controllers/client.ts
+++ b/server/controllers/client.ts
@@ -39,6 +39,7 @@ const controllers: IControllerClient = {
       sort: querySort,
       pagination: queryPagination,
       fields,
+      omit = [],
       ...filterQuery
     } = query || {};
 
@@ -52,6 +53,7 @@ const controllers: IControllerClient = {
           sort: sort || querySort,
           pagination: pagination || queryPagination,
           fields,
+          omit,
         })
       );
     } catch (e: ToBeFixed) {
@@ -66,7 +68,7 @@ const controllers: IControllerClient = {
     const { params, query, sort } = ctx;
     const { relation } = parseParams<{ relation: string }>(params);
 
-    const { sort: querySort, fields, ...filterQuery } = query || {};
+    const { sort: querySort, fields, omit, ...filterQuery } = query || {};
 
     try {
       assertParamsPresent<{ relation: string }>(params, ["relation"]);
@@ -78,6 +80,7 @@ const controllers: IControllerClient = {
             query: filterQuery,
             sort: sort || querySort,
             fields,
+            omit,
           }),
           dropBlockedThreads: true,
         }
@@ -98,6 +101,7 @@ const controllers: IControllerClient = {
       sort: querySort,
       pagination: queryPagination,
       fields,
+      omit = [],
       ...filterQuery
     } = query || {};
 
@@ -110,6 +114,7 @@ const controllers: IControllerClient = {
           sort: sort || querySort,
           pagination: pagination || queryPagination,
           fields,
+          omit,
         }),
         id,
         ![AUTHOR_TYPE.GENERIC.toLowerCase(), AUTHOR_TYPE.GENERIC].includes(type)

--- a/server/controllers/utils/parsers.ts
+++ b/server/controllers/utils/parsers.ts
@@ -6,7 +6,7 @@ import { assertNotEmpty } from "../../utils/functions";
 export const flatInput = <T, TKeys = keyof T>(
   payload: FlatInput<OnlyStrings<TKeys>>
 ) => {
-  const { relation, query, sort, pagination, fields } = payload;
+  const { relation, query, sort, pagination, fields, omit } = payload;
 
   const { populate = {}, filterBy, filterByValue, ...restQuery } = query;
   const filters = restQuery?.filters || restQuery;
@@ -81,5 +81,6 @@ export const flatInput = <T, TKeys = keyof T>(
     pagination,
     sort,
     fields,
+    omit,
   };
 };

--- a/server/services/admin.ts
+++ b/server/services/admin.ts
@@ -212,6 +212,7 @@ export = ({ strapi }: StrapiContext): IServiceAdmin => ({
           this.getCommonService().sanitizeCommentEntity(
             _,
             [],
+            [],
             defaultAuthorUserPopulate?.populate,
           ),
         ),
@@ -325,6 +326,7 @@ export = ({ strapi }: StrapiContext): IServiceAdmin => ({
               gotThread: isCommentWithThread,
             }, []),
           },
+          [],
           [],
           defaultAuthorUserPopulate?.populate,
         ),
@@ -445,6 +447,7 @@ export = ({ strapi }: StrapiContext): IServiceAdmin => ({
         ...entity,
         threadOf: entity.threadOf || null,
       },
+      [],
       [],
       defaultAuthorUserPopulate?.populate,
     );

--- a/types/controllers.d.ts
+++ b/types/controllers.d.ts
@@ -43,6 +43,7 @@ export type FlatInput<TKeys extends string> = {
   relation?: Id;
   pagination?: ToBeFixed;
   fields?: StrapiRequestQueryFieldsClause<TKeys>;
+  omit?: Array<string>
 };
 
 export type ThrowableResponse<T> = T | PluginError | never;

--- a/types/services.d.ts
+++ b/types/services.d.ts
@@ -43,7 +43,8 @@ export type FindAllFlatProps<T, TFields = keyof T> = {
   sort?: StringMap<unknown>;
   fields?: StrapiRequestQueryFieldsClause<OnlyStrings<TFields>>;
   pagination?: StrapiPagination;
-  isAdmin?: boolean
+  isAdmin?: boolean;
+  omit?: Array<string>;
 };
 
 export type FindAllInHierarchyProps = Omit<FindAllFlatProps, "pagination"> & {
@@ -106,6 +107,7 @@ export interface IServiceCommon {
   sanitizeCommentEntity(
     entity: Comment,
     blockedAuthorProps: string[],
+    omit?: string[],
     populate?: PopulateClause<OnlyStrings<keyof StrapiUser>>,
   ): Comment;
   isValidUserContext(user?: any): boolean;


### PR DESCRIPTION
## Ticket

https://github.com/VirtusLab-Open-Source/strapi-plugin-comments/issues/239

## Summary

What does this PR do/solve?

- fields of comment entity can be skipped

## Test Plan

- start the server
- make a API call like `http://localhost:1337/api/comments/<id>?omit[]=blocked&omit[]=related&omit[]=author`
- response should not contain specified fields