### PR TITLE
fix/322: add `isAdminComment` to the filters

### DIFF
--- a/server/src/bootstrap.ts
+++ b/server/src/bootstrap.ts
@@ -1,7 +1,6 @@
 import { StrapiContext } from './@types';
 import { setupGQL } from './graphql';
 import permissions from './permissions';
-import { CONFIG_PARAMS } from './utils/constants';
 import { getPluginService } from './utils/getPluginService';
 
 export default async ({ strapi }: StrapiContext) => {

--- a/server/src/validators/api/controllers/client.controller.validator.ts
+++ b/server/src/validators/api/controllers/client.controller.validator.ts
@@ -72,6 +72,7 @@ const getBaseFindSchema = (enabledCollections: string[]) => {
         blocked: true,
         blockedThread: true,
         approvalStatus: true,
+        isAdminComment: true,
       }).optional(),
       isAdmin: z.boolean().optional().default(false),
       populate: z


### PR DESCRIPTION
## Ticket

https://github.com/VirtusLab/strapi-plugin-comments/issues/322

## Summary

What does this PR do/solve?
Add isAdminComment to the filters

> PRs should be as small as they need to be, if this section starts becoming a novel you should _seriously_ consider breaking it up into multiple PRs

## Test Plan

How are you testing the work you're submitting?
