### PR TITLE
fix/317: read report reasons from local config

### DIFF
--- a/admin/src/api/schemas.ts
+++ b/admin/src/api/schemas.ts
@@ -5,11 +5,7 @@ export const configSchema = z.object({
   entryLabel: z.record(z.array(z.string())),
   approvalFlow: z.array(z.string()),
   blockedAuthorProps: z.array(z.string()),
-  reportReasons: z.object({
-    BAD_LANGUAGE: z.literal('BAD_LANGUAGE'),
-    DISCRIMINATION: z.literal('DISCRIMINATION'),
-    OTHER: z.literal('OTHER'),
-  }),
+  reportReasons: z.record(z.string()),
   regex: z.object({
     uid: z.string(),
     relatedUid: z.string(),
@@ -20,13 +16,17 @@ export const configSchema = z.object({
   moderatorRoles: z.array(z.string()),
   isGQLPluginEnabled: z.boolean(),
   badWords: z.boolean().nullable().optional(),
-  gql: z.object({
-    auth: z.boolean().nullable(),
-  }).optional(),
-  client: z.object({
-    url: z.string().nullable(),
-    contactEmail: z.string().nullable(),
-  }).default({ url: null, contactEmail: null }),
+  gql: z
+    .object({
+      auth: z.boolean().nullable(),
+    })
+    .optional(),
+  client: z
+    .object({
+      url: z.string().nullable(),
+      contactEmail: z.string().nullable(),
+    })
+    .default({ url: null, contactEmail: null }),
 });
 
 

--- a/server/src/repositories/store.repository.ts
+++ b/server/src/repositories/store.repository.ts
@@ -37,16 +37,18 @@ export const getStoreRepositorySource = (strapi: CoreStrapi) => {
         ),
       };
       const isGQLPluginEnabled = !!strapi.plugin('graphql');
+      const reportReasons = this.getLocalConfig('reportReasons');
       if (config) {
+        // TODO: add report reasons to config page
         return makeRight({
           ...config,
           ...additionalConfiguration,
+          reportReasons,
           isGQLPluginEnabled: viaSettingsPage ? isGQLPluginEnabled : undefined,
         });
       }
       const entryLabel = this.getLocalConfig('entryLabel');
       const approvalFlow = this.getLocalConfig('approvalFlow');
-      const reportReasons = this.getLocalConfig('reportReasons');
       const blockedAuthorProps = this.getLocalConfig('blockedAuthorProps');
 
       const result = {


### PR DESCRIPTION
## Ticket

https://github.com/VirtusLab/strapi-plugin-comments/issues/317

## Summary

After verification on the settings page, we can't set up report reasons, so we should always read from the local config - not from the store, because the user can't edit it.

> PRs should be as small as they need to be, if this section starts becoming a novel you should _seriously_ consider breaking it up into multiple PRs

## Test Plan

How are you testing the work you're submitting?
