### PR TITLE
fix: aria-label in side navbar

### DIFF
--- a/admin/src/components/ApproveFlow/index.tsx
+++ b/admin/src/components/ApproveFlow/index.tsx
@@ -6,7 +6,7 @@ import { FC } from 'react';
 import { useAPI } from '../../hooks/useAPI';
 import { pluginId } from '../../pluginId';
 import { AllowedActions } from '../../types';
-import { handleAPIError } from '../../utils';
+import { getMessage, handleAPIError } from '../../utils';
 
 export const ApproveFlow: FC<{ id: number, canModerate: AllowedActions['canModerate'], queryKey?: string[] }> = ({ id, canModerate, queryKey }) => {
   const { toggleNotification } = useNotification();

--- a/admin/src/components/SideNav/index.tsx
+++ b/admin/src/components/SideNav/index.tsx
@@ -4,7 +4,7 @@ import { getMessage } from '../../utils';
 
 export const SideNav = () => {
   return (
-    <SubNav ariaLabel="Comments sub nav">
+    <SubNav aria-label="Comments sub nav">
       <SubNavHeader label={getMessage('plugin.name')} />
       <SubNavSections>
         <SubNavSection label={getMessage('nav.header.moderation')}>

--- a/admin/src/components/Wysiwyg/WysiwygNav.tsx
+++ b/admin/src/components/Wysiwyg/WysiwygNav.tsx
@@ -28,6 +28,7 @@ import { EditorFromTextArea } from 'codemirror5';
 import { useIntl } from 'react-intl';
 
 import { IconButtonGroupMargin, MainButtons, MoreButton } from './WysiwygStyles';
+import { getMessage } from '../../utils';
 
 interface WysiwygNavProps {
   disabled?: boolean;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "strapi-plugin-comments",
-  "version": "3.0.14",
+  "version": "3.0.15",
   "description": "Strapi - Comments plugin",
   "strapi": {
     "name": "comments",


### PR DESCRIPTION
## Ticket

https://github.com/VirtusLab/strapi-plugin-comments/issues/332

## Summary

What does this PR do/solve?

 - change `ariaLabel` props to `aria-label` in SideNavbar so it is rendered correctly in the DOM
 - add `getMessage` to lacking imports after merging translations
