### PR TITLE
fix: Strapi user relations

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "strapi-plugin-comments",
-  "version": "3.0.16",
+  "version": "3.1.0-beta.1",
   "description": "Strapi - Comments plugin",
   "strapi": {
     "name": "comments",

--- a/server/src/controllers/__tests__/client.controller.test.ts
+++ b/server/src/controllers/__tests__/client.controller.test.ts
@@ -130,7 +130,10 @@ describe('Client controller', () => {
           },
           threadOf: {
             populate: {
-              authorUser: true
+              authorUser: {
+                populate: true,
+                avatar: { populate: true },
+              },
             }
           }
         }
@@ -179,7 +182,10 @@ describe('Client controller', () => {
           },
           threadOf: {
             populate: {
-              authorUser: true
+              authorUser: {
+                populate: true,
+                avatar: { populate: true },
+              },
             }
           }
         }
@@ -222,7 +228,10 @@ describe('Client controller', () => {
           },
           threadOf: {
             populate: {
-              authorUser: true
+              authorUser: {
+                populate: true,
+                avatar: { populate: true },
+              },
             }
           }
         }
@@ -259,7 +268,10 @@ describe('Client controller', () => {
           },
           threadOf: {
             populate: {
-              authorUser: true
+              authorUser: {
+                populate: true,
+                avatar: { populate: true },
+              },
             }
           }
         }

--- a/server/src/controllers/__tests__/utils/parser.test.ts
+++ b/server/src/controllers/__tests__/utils/parser.test.ts
@@ -20,7 +20,12 @@ describe('Parser', () => {
           },
           threadOf: {
             populate: {
-              authorUser: true,
+              authorUser: {
+                populate: true,
+                avatar: {
+                  populate: true,
+                }
+              },
             },
           },
         },
@@ -77,7 +82,10 @@ describe('Parser', () => {
           },
           threadOf: {
             populate: {
-              authorUser: true,
+              authorUser: {
+                populate: true,
+                avatar: { populate: true },
+              },
             },
           },
         },
@@ -134,7 +142,10 @@ describe('Parser', () => {
           },
           threadOf: {
             populate: {
-              authorUser: true,
+              authorUser: {
+                populate: true,
+                avatar: { populate: true },
+              },
             },
           },
         },
@@ -203,7 +214,10 @@ describe('Parser', () => {
           },
           threadOf: {
             populate: {
-              authorUser: true,
+              authorUser: {
+                populate: true,
+                avatar: { populate: true },
+              },
             },
           },
         },
@@ -242,7 +256,10 @@ describe('Parser', () => {
           },
           threadOf: {
             populate: {
-              authorUser: true,
+              authorUser: {
+                populate: true,
+                avatar: { populate: true },
+              },
             },
           },
         },
@@ -287,7 +304,10 @@ describe('Parser', () => {
           },
           threadOf: {
             populate: {
-              authorUser: true,
+              authorUser: {
+                populate: true,
+                avatar: { populate: true },
+              },
             },
           },
         },

--- a/server/src/controllers/utils/parsers.ts
+++ b/server/src/controllers/utils/parsers.ts
@@ -51,7 +51,12 @@ export const flatInput = <T extends FlatInputParams>(payload: T): T => {
   let threadOfPopulate = {
     threadOf: {
       populate: {
-        authorUser: true,
+        authorUser: {
+          populate: true,
+          avatar: {
+            populate: true,
+          },
+        },
         ...populate,
       } as {
         authorUser: boolean | { populate: boolean };

--- a/server/src/services/__tests__/client.service.test.ts
+++ b/server/src/services/__tests__/client.service.test.ts
@@ -15,6 +15,19 @@ jest.mock('../../utils/getPluginService', () => ({
   getPluginService: jest.fn(),
 }));
 
+const defaultPopulate = {
+  authorUser: {
+    populate: ['avatar'],
+  },
+};
+
+const defaultThreadOfPopulate = {
+  threadOf: true,
+  authorUser: {
+    populate: ['avatar'],
+  },
+};
+
 describe('client.service', () => {
   const mockCommonService = {
     parseRelationString: jest.fn(),
@@ -152,16 +165,14 @@ describe('client.service', () => {
       expect(result).toEqual(mockSanitizedEntity);
       expect(mockCommentRepository.create).toHaveBeenCalledWith({
         data: {
-          authorId: mockUser.id,
-          authorEmail: mockUser.email,
-          authorName: mockUser.username,
-          authorAvatar: 'avatar-url',
+          authorUser: mockUser.id,
           content: 'Test comment',
           related: 'api::test.test:1',
           approvalStatus: APPROVAL_STATUS.PENDING,
           locale: 'en',
           threadOf: null,
         },
+        populate: defaultPopulate,
       });
     });
 
@@ -211,6 +222,7 @@ describe('client.service', () => {
           locale: 'en',
           threadOf: null,
         },
+        populate: defaultPopulate,
       });
     });
 
@@ -240,16 +252,14 @@ describe('client.service', () => {
       expect(result).toEqual(mockSanitizedEntity);
       expect(mockCommentRepository.create).toHaveBeenCalledWith({
         data: {
-          authorId: mockUser.id,
-          authorEmail: mockUser.email,
-          authorName: mockUser.username,
-          authorAvatar: null,
+          authorUser: mockUser.id,
           content: 'Test comment',
           related: 'api::test.test:1',
           approvalStatus: APPROVAL_STATUS.APPROVED,
           locale: 'en',
           threadOf: null,
         },
+        populate: defaultPopulate,
       });
     });
 
@@ -299,7 +309,7 @@ describe('client.service', () => {
       expect(mockCommentRepository.update).toHaveBeenCalledWith({
         where: { id: 1 },
         data: { content: 'Updated comment' },
-        populate: { threadOf: true, authorUser: true },
+        populate: defaultThreadOfPopulate,
       });
     });
 
@@ -322,7 +332,7 @@ describe('client.service', () => {
       expect(mockCommentRepository.update).toHaveBeenCalledWith({
         where: { id: 1 },
         data: { content: 'Updated comment' },
-        populate: { threadOf: true, authorUser: true },
+        populate: defaultThreadOfPopulate,
       });
     });
 
@@ -446,7 +456,7 @@ describe('client.service', () => {
           related: 'api::test.test:1',
         },
         data: { removed: true },
-        populate: { threadOf: true, authorUser: true },
+        populate: defaultThreadOfPopulate,
       });
     });
 

--- a/server/src/services/__tests__/client.service.test.ts
+++ b/server/src/services/__tests__/client.service.test.ts
@@ -52,6 +52,10 @@ describe('client.service', () => {
     findOne: jest.fn(),
   });
 
+  const mockEmailService = {
+    send: jest.fn(),
+  };
+
   beforeEach(() => {
     jest.clearAllMocks();
     caster<jest.Mock>(getPluginService).mockReturnValue(mockCommonService);
@@ -218,6 +222,31 @@ describe('client.service', () => {
         },
         populate: defaultPopulate,
       });
+    });
+
+    it('should throw error when no user is provided', async () => {
+      const strapi = getStrapi();
+      const service = getService(strapi);
+
+      const mockEntity = { id: 1, content: 'Test comment' };
+      const mockSanitizedEntity = { id: 1, content: 'Clean comment' };
+
+      mockCommonService.parseRelationString.mockReturnValue({
+        uid: 'api::test.test',
+        relatedId: '1',
+      });
+      mockFindOne.mockResolvedValue({ id: 1 });
+      mockCommonService.getConfig.mockResolvedValue([]);
+      mockCommonService.isValidUserContext.mockReturnValue(false);
+      mockCommonService.checkBadWords.mockResolvedValue('Test comment');
+      mockCommentRepository.create.mockResolvedValue(mockEntity);
+      mockCommonService.sanitizeCommentEntity.mockReturnValue(
+        mockSanitizedEntity
+      );
+
+      await expect(service.create(mockPayload)).rejects.toThrow(
+        PluginError
+      );
     });
 
     it('should throw error when relation does not exist', async () => {

--- a/server/src/services/__tests__/client.service.test.ts
+++ b/server/src/services/__tests__/client.service.test.ts
@@ -120,22 +120,16 @@ describe('client.service', () => {
       const result = await service.create(mockPayload, mockUser);
 
       expect(result).toEqual(mockSanitizedEntity);
-      expect(mockUserQuery().findOne).toHaveBeenCalledWith({
-        where: { id: mockUser.id },
-        populate: ['avatar'],
-      });
       expect(mockCommentRepository.create).toHaveBeenCalledWith({
         data: {
-          authorId: mockUser.id,
-          authorEmail: mockUser.email,
-          authorName: mockUser.username,
-          authorAvatar: 'avatar-url',
+          authorUser: mockUser.id,
           content: 'Test comment',
           related: 'api::test.test:1',
           approvalStatus: APPROVAL_STATUS.APPROVED,
           locale: 'en',
           threadOf: null,
         },
+        populate: defaultPopulate,
       });
     });
 
@@ -216,43 +210,6 @@ describe('client.service', () => {
           authorName: mockAuthor.name,
           authorEmail: mockAuthor.email,
           authorAvatar: mockAuthor.avatar,
-          content: 'Test comment',
-          related: 'api::test.test:1',
-          approvalStatus: APPROVAL_STATUS.APPROVED,
-          locale: 'en',
-          threadOf: null,
-        },
-        populate: defaultPopulate,
-      });
-    });
-
-    it('should handle user with no avatar properly', async () => {
-      const strapi = getStrapi();
-      const service = getService(strapi);
-      const mockEntity = { id: 1, content: 'Test comment' };
-      const mockSanitizedEntity = { id: 1, content: 'Clean comment' };
-      const mockDbUserNoAvatar = { id: 1 }; // User without avatar
-
-      mockCommonService.parseRelationString.mockReturnValue({
-        uid: 'api::test.test',
-        relatedId: '1',
-      });
-      mockFindOne.mockResolvedValue({ id: 1 });
-      mockCommonService.getConfig.mockResolvedValue([]);
-      mockCommonService.isValidUserContext.mockReturnValue(true);
-      mockCommonService.checkBadWords.mockResolvedValue('Test comment');
-      mockCommentRepository.create.mockResolvedValue(mockEntity);
-      mockCommonService.sanitizeCommentEntity.mockReturnValue(
-        mockSanitizedEntity
-      );
-      mockUserQuery().findOne.mockResolvedValue(mockDbUserNoAvatar);
-
-      const result = await service.create(mockPayload, mockUser);
-
-      expect(result).toEqual(mockSanitizedEntity);
-      expect(mockCommentRepository.create).toHaveBeenCalledWith({
-        data: {
-          authorUser: mockUser.id,
           content: 'Test comment',
           related: 'api::test.test:1',
           approvalStatus: APPROVAL_STATUS.APPROVED,

--- a/server/src/services/__tests__/common.service.test.ts
+++ b/server/src/services/__tests__/common.service.test.ts
@@ -503,7 +503,12 @@ describe('common.service', () => {
       expect(mockCommentRepository.findWithCount).toHaveBeenCalledWith({
         pageSize: 10, 
         page: 1,
-        populate: { authorUser: { populate: ['avatar'] } }, 
+        populate: { 
+          authorUser: {
+            populate: true,
+            avatar: { populate: true },
+          }, 
+        }, 
         select: ["id", "content", "related"],
         orderBy: { createdAt: "desc" },
         where: { authorId: 1 }
@@ -550,7 +555,10 @@ describe('common.service', () => {
         select: ['id', 'content', 'related'],
         orderBy: { createdAt: 'desc' },
         populate: {
-          authorUser: { populate: ['avatar'] },
+          authorUser: {
+            populate: true,
+            avatar: { populate: true },
+          },
         },
       });
     });

--- a/server/src/services/__tests__/common.service.test.ts
+++ b/server/src/services/__tests__/common.service.test.ts
@@ -503,7 +503,7 @@ describe('common.service', () => {
       expect(mockCommentRepository.findWithCount).toHaveBeenCalledWith({
         pageSize: 10, 
         page: 1,
-        populate: { authorUser: true }, 
+        populate: { authorUser: { populate: ['avatar'] } }, 
         select: ["id", "content", "related"],
         orderBy: { createdAt: "desc" },
         where: { authorId: 1 }
@@ -550,7 +550,7 @@ describe('common.service', () => {
         select: ['id', 'content', 'related'],
         orderBy: { createdAt: 'desc' },
         populate: {
-          authorUser: true,
+          authorUser: { populate: ['avatar'] },
         },
       });
     });

--- a/server/src/services/__tests__/common.service.test.ts
+++ b/server/src/services/__tests__/common.service.test.ts
@@ -156,7 +156,9 @@ describe('common.service', () => {
         where: { id: 1 },
         populate: {
           reports: true,
-          authorUser: true,
+          authorUser: {
+            populate: ['avatar'],
+          },
         },
       });
     });

--- a/server/src/services/__tests__/common.service.test.ts
+++ b/server/src/services/__tests__/common.service.test.ts
@@ -226,6 +226,38 @@ describe('common.service', () => {
       expect(result.data).toHaveLength(2);
       expect(mockCommentRepository.findWithCount).toHaveBeenCalled();
     });
+    it('should return flat list of comments with populated user properties', async () => {
+      const strapi = getStrapi();
+      const service = getService(strapi);
+      const mockComments = [
+        { id: 1, content: 'Comment 1', avatar: { url: 'avatar2.png' } },
+        { id: 2, content: 'Comment 2', avatar: { url: 'avatar2.png' } },
+      ];
+
+      mockCommentRepository.findWithCount.mockResolvedValue({
+        results: mockComments,
+        pagination: { total: 2 },
+      });
+      caster<jest.Mock>(getOrderBy).mockReturnValue(['createdAt', 'desc']);
+      
+      mockStoreRepository.getConfig.mockResolvedValue([]);
+
+      const result = await service.findAllFlat({
+        fields: ['id', 'content'],
+        limit: 10,
+        skip: 0,
+        populate: {
+          authorUser: {
+            avatar: {
+              populate: true
+            }
+          }
+        }
+      });
+
+      expect(result.data).toHaveLength(2);
+      expect(mockCommentRepository.findWithCount).toHaveBeenCalled();
+    });
   });
 
   describe('modifiedNestedNestedComments', () => {

--- a/server/src/services/client.service.ts
+++ b/server/src/services/client.service.ts
@@ -294,6 +294,10 @@ export const clientService = ({ strapi }: StrapiContext) => {
           const emailSender = await this.getCommonService().getConfig('client.contactEmail', superAdmin.email);
           const clientAppUrl = await this.getCommonService().getConfig('client.url', 'our site');
 
+          if (!emailSender) {
+            return;
+          }
+
           try {
             await strapi
             .plugin('email')

--- a/server/src/services/client.service.ts
+++ b/server/src/services/client.service.ts
@@ -294,10 +294,6 @@ export const clientService = ({ strapi }: StrapiContext) => {
           const emailSender = await this.getCommonService().getConfig('client.contactEmail', superAdmin.email);
           const clientAppUrl = await this.getCommonService().getConfig('client.url', 'our site');
 
-          if (!emailSender) {
-            return;
-          }
-
           try {
             await strapi
             .plugin('email')

--- a/server/src/services/common.service.ts
+++ b/server/src/services/common.service.ts
@@ -86,8 +86,11 @@ const commonService = ({ strapi }: StrapiContext) => ({
     const omit = baseOmit.filter((field) => !REQUIRED_FIELDS.includes(field));
     const defaultSelect = (['id', 'related'] as const).filter((field) => !omit.includes(field));
 
-    const populateClause = {
-      authorUser: { populate: ['avatar'] },
+    const populateClause: clientValidator.FindAllFlatSchema['populate'] = {
+      authorUser: { 
+        populate: true,
+        avatar: { populate: true } 
+      },
       ...(isObject(populate) ? populate : {}),
     };
     const doNotPopulateAuthor = isAdmin ? [] : await this.getConfig(CONFIG_PARAMS.AUTHOR_BLOCKED_PROPS, []);
@@ -136,7 +139,7 @@ const commonService = ({ strapi }: StrapiContext) => ({
 
       let authorUserPopulate = {};
       if (isObject(populate?.authorUser)) {
-        authorUserPopulate = 'populate' in populateClause.authorUser ? (populateClause.authorUser.populate) : populateClause.authorUser;
+        authorUserPopulate = 'populate' in populate.authorUser ? (populate.authorUser.populate) : populateClause.authorUser;
       }
 
       const primitiveThreadOf = typeof parsedThreadOf === 'number' ? parsedThreadOf : null;

--- a/server/src/services/common.service.ts
+++ b/server/src/services/common.service.ts
@@ -135,7 +135,7 @@ const commonService = ({ strapi }: StrapiContext) => ({
       const parsedThreadOf = 'threadOf' in filters ? (isString(filters.threadOf) ? parseInt(filters.threadOf) : filters.threadOf) : null;
 
       let authorUserPopulate = {};
-      if (isObject(populateClause?.authorUser)) {
+      if (isObject(populate?.authorUser)) {
         authorUserPopulate = 'populate' in populateClause.authorUser ? (populateClause.authorUser.populate) : populateClause.authorUser;
       }
 

--- a/server/src/services/common.service.ts
+++ b/server/src/services/common.service.ts
@@ -86,8 +86,8 @@ const commonService = ({ strapi }: StrapiContext) => ({
     const omit = baseOmit.filter((field) => !REQUIRED_FIELDS.includes(field));
     const defaultSelect = (['id', 'related'] as const).filter((field) => !omit.includes(field));
 
-    const populateClause: clientValidator.FindAllFlatSchema['populate'] = {
-      authorUser: true,
+    const populateClause = {
+      authorUser: { populate: ['avatar'] },
       ...(isObject(populate) ? populate : {}),
     };
     const doNotPopulateAuthor = isAdmin ? [] : await this.getConfig(CONFIG_PARAMS.AUTHOR_BLOCKED_PROPS, []);
@@ -192,7 +192,7 @@ const commonService = ({ strapi }: StrapiContext) => ({
       where: criteria,
       populate: {
         reports: true,
-        authorUser: true,
+        authorUser: { populate: ['avatar'] },
       },
     });
     if (!entity) {

--- a/server/src/services/utils/functions.ts
+++ b/server/src/services/utils/functions.ts
@@ -5,11 +5,24 @@ import { REGEX } from '../../utils/constants';
 import PluginError from '../../utils/error';
 import { Comment, CommentWithRelated } from '../../validators/repositories';
 
+type Avatar = {
+  url: string;
+  name: string;
+  hash: string;
+}
+
 interface StrapiAuthorUser {
   id: Id;
   username: string;
   email: string;
-  avatar?: string | object;
+  avatar?: Avatar & {
+    formats: {
+      thumbnail?: Avatar;
+      small?: Avatar;
+      medium?: Avatar;
+      large?: Avatar;
+    }
+  };
   [key: string]: unknown;
 }
 
@@ -89,7 +102,7 @@ export const buildAuthorModel = (
         id: user.id,
         name: user.username,
         email: user.email,
-        avatar: user.avatar,
+        avatar: user.avatar?.formats?.thumbnail.url || user.avatar?.url,
       },
     );
   } else if (authorId) {

--- a/server/src/validators/repositories/comment.schema.ts
+++ b/server/src/validators/repositories/comment.schema.ts
@@ -1,5 +1,24 @@
 import { z } from 'zod';
 
+const fileInfoSchema = z.object({
+  url: z.string(),
+  name: z.string(),
+  hash: z.string(),
+});
+
+const avatarSchema = z.object({
+  id: z.number(),
+  ...fileInfoSchema.shape,
+  formats: z
+    .object({
+      thumbnail: fileInfoSchema.optional(),
+      small: fileInfoSchema.optional(),
+      medium: fileInfoSchema.optional(),
+      large: fileInfoSchema.optional(),
+    })
+    .optional(),
+}).nullable().optional();
+
 export const dbBaseCommentSchema = z.object({
   id: z.number(),
   documentId: z.string().nullable(),
@@ -18,6 +37,14 @@ export const dbBaseCommentSchema = z.object({
   authorName: z.string().nullable(),
   authorEmail: z.string().email().nullable(),
   authorAvatar: z.string().nullable(),
-  authorUser: z.union([z.string(), z.object({ id: z.number(), email: z.string().email() })]).optional().nullable(),
+  authorUser: z.union([
+    z.string(), 
+    z.object({ 
+      id: z.number(), 
+      username: z.string(), 
+      email: z.string().email(),
+      avatar: avatarSchema,
+    })
+  ]).optional().nullable(),
   locale: z.string().nullable(),
 });


### PR DESCRIPTION
## Ticket

https://github.com/VirtusLab/strapi-plugin-comments/issues/333

## Summary

 PR ensures that Strapi users are related to the User collection from `plugin::users-permissions.user`. This way, the username, email, and avatar should be connected to the User data, and in the case of an update, they should be populated in the comment data.

## Test Plan

 - Test all endpoints for the Strapi and Non-Strapi users, see if Avatars are populated correctly.
