### PR TITLE
fix: provide correct theme props

### DIFF
--- a/admin/src/providers/CommonProviders/index.tsx
+++ b/admin/src/providers/CommonProviders/index.tsx
@@ -13,11 +13,11 @@ const queryClient = new QueryClient({
   },
 });
 export const CommonProviders: FC<{ children: ReactNode }> = ({ children }) => {
+  const { theme } = usePluginTheme();
 
-  const theme = usePluginTheme();
   return (
     <QueryClientProvider client={queryClient}>
-      <DesignSystemProvider theme={{ theme }}>
+      <DesignSystemProvider theme={theme}>
         <UserProvider>
           {children}
         </UserProvider>


### PR DESCRIPTION
## Ticket

https://github.com/VirtusLab/strapi-plugin-comments/issues/337

## Summary

Resolve the issue of having a blank screen for plugin-related pages while using the `system` theme of Strapi.

## Test Plan

1. Run Strapi with `system` theme enabled
2. See if it works
3. Do points 1 and 2 for other themes
