### PR TITLE
fix: discussion admin panel

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "strapi-plugin-comments",
-  "version": "3.1.0",
+  "version": "3.1.1-beta.1",
   "description": "Strapi - Comments plugin",
   "strapi": {
     "name": "comments",

--- a/server/src/services/common.service.ts
+++ b/server/src/services/common.service.ts
@@ -197,8 +197,8 @@ const commonService = ({ strapi }: StrapiContext) => ({
     const children = await this.findAllFlat(
       {
         filters: {
-          threadOf: { $eq: entry.id.toString() },
           ...filters,
+          threadOf: { $eq: entry.id.toString() },
         },
         populate,
         sort,
@@ -206,11 +206,10 @@ const commonService = ({ strapi }: StrapiContext) => ({
         isAdmin,
         omit,
         locale,
-        limit: Infinity,
+        limit: Number.MAX_SAFE_INTEGER,
       },
       relatedEntity,
     );
-
     const allChildren =
       entry.blockedThread && dropBlockedThreads
         ? []


### PR DESCRIPTION
## Ticket

https://github.com/VirtusLab/strapi-plugin-comments/issues/349
https://github.com/VirtusLab/strapi-plugin-comments/issues/352

## Summary

This PR changes the order of reading of the `threadsOf` property in the `getCommentsChildren` function. It avoids infinite loops while getting a list of comments assigned to a certain article.

## Test Plan
 - Create a comment with the thread started
 - Go to the admin panel and click on the `View` button related to the comment with threads
 - Check if you can see the discussion
 - Check API endpoints for getting comments
