### PR TITLE
Allow to display comments in discover threads page if there is a missing e-mail address in author data

### DIFF
--- a/admin/src/api/schemas.ts
+++ b/admin/src/api/schemas.ts
@@ -49,7 +49,7 @@ const relatedSchema = z.intersection(
 const authorSchema = z.object({
   id: z.union([z.number(), z.string()]),
   name: z.string().optional().nullable(),
-  email: z.string(),
+  email: z.string().nullable(),
   avatar: z
     .union([
       z.object({

--- a/admin/src/components/CommentRow/index.tsx
+++ b/admin/src/components/CommentRow/index.tsx
@@ -48,7 +48,7 @@ export const CommentRow: FC<Props> = ({ item }) => {
 
     return (
       <Tooltip label={related.title}>
-        <Link 
+        <Link
           width="100%"
           overflow="hidden"
           href={`/admin/content-manager/collection-types/${related.uid}/${related.documentId}${localeParam}`}
@@ -69,7 +69,7 @@ export const CommentRow: FC<Props> = ({ item }) => {
       <Td>
         <Tooltip
           open={item.isAdminComment ? false : undefined}
-          label={!item.isAdminComment ? email : undefined}
+          label={!item.isAdminComment ? email || getMessage('page.discover.table.header.author.email') : undefined}
           align="start"
           side="left">
           <Flex gap={2} style={{ cursor: item.isAdminComment ? 'default' : 'help' }}>

--- a/admin/src/components/DiscussionThreadItem/DiscussionThreadItemFooter.tsx
+++ b/admin/src/components/DiscussionThreadItem/DiscussionThreadItemFooter.tsx
@@ -27,7 +27,7 @@ export const DiscussionThreadItemFooter: FC<PropsWithChildren<DiscussionThreadIt
       <DiscussionThreadItemFooterMeta>
         <Tooltip
           open={item.isAdminComment ? false : undefined}
-          label={!item.isAdminComment ? email : undefined}
+          label={!item.isAdminComment ? email || getMessage('page.discover.table.header.author.email') : undefined}
           align="start"
           side="left">
           <Flex style={{ cursor: item.isAdminComment ? "default" : "help" }}>

--- a/admin/src/translations/en.ts
+++ b/admin/src/translations/en.ts
@@ -27,6 +27,7 @@ const en = {
   'page.discover.header.count': '{count} entries found',
   'page.discover.table.header.id': 'ID',
   'page.discover.table.header.author': 'Author',
+  'page.discover.table.header.author.email': 'E-mail not provided',
   'page.discover.table.header.message': 'Message',
   'page.discover.table.header.thread': 'Thread of',
   'page.discover.table.header.entry': 'Entry',

--- a/admin/src/translations/fr.ts
+++ b/admin/src/translations/fr.ts
@@ -29,6 +29,7 @@ export default {
   'page.discover.header.count': '{count} entrées trouvées',
   'page.discover.table.header.id': 'ID',
   'page.discover.table.header.author': 'Auteur',
+  'page.discover.table.header.author.email': 'E-mail non fourni',
   'page.discover.table.header.message': 'Message',
   'page.discover.table.header.thread': 'Fil de discussion de',
   'page.discover.table.header.entry': 'Entrée',

--- a/admin/src/translations/pl.ts
+++ b/admin/src/translations/pl.ts
@@ -27,6 +27,7 @@ export default {
   "page.discover.header.count": "{count} znalezionych wpisów",
   "page.discover.table.header.id": "ID",
   "page.discover.table.header.author": "Autor",
+  'page.discover.table.header.author.email': 'Adres e-mail nie podany',
   "page.discover.table.header.message": "Wiadomość",
   "page.discover.table.header.thread": "Wątek",
   "page.discover.table.header.entry": "Wpis",

--- a/admin/src/translations/pt-BR.ts
+++ b/admin/src/translations/pt-BR.ts
@@ -24,6 +24,7 @@ export default {
   'page.discover.header.count': '{count} entries found',
   'page.discover.table.header.id': 'ID',
   'page.discover.table.header.author': 'Autor',
+  'page.discover.table.header.author.email': 'E-mail não fornecido',
   'page.discover.table.header.message': 'Messagem',
   'page.discover.table.header.thread': 'Thread of',
   'page.discover.table.header.entry': 'Entry',
@@ -143,4 +144,4 @@ export default {
   'components.toogle.enabled': 'Habilitado',
   'components.toogle.disabled': 'Desabilitado',
   'components.author.unknown': 'Autor removido',
-} satisfies  CommentsPluginTranslations;
+} satisfies CommentsPluginTranslations;

--- a/admin/src/translations/ru.ts
+++ b/admin/src/translations/ru.ts
@@ -27,6 +27,7 @@ export default {
   'page.discover.header.count': '{count} записей найдено',
   'page.discover.table.header.id': 'ID',
   'page.discover.table.header.author': 'Автор',
+  'page.discover.table.header.author.email': 'E‑mail не указан',
   'page.discover.table.header.message': 'Сообщение',
   'page.discover.table.header.thread': 'Тема',
   'page.discover.table.header.entry': 'Запись',
@@ -193,4 +194,4 @@ export default {
   'customField.comments.input.populate.label': 'Заполнить',
   'customField.comments.input.populate.author.label': 'Заполнить поле автора',
   'customField.comments.input.populate.avatar.label': 'Заполнить поле аватар',
-}satisfies CommentsPluginTranslations;
+} satisfies CommentsPluginTranslations;

--- a/admin/src/translations/tr.ts
+++ b/admin/src/translations/tr.ts
@@ -27,6 +27,7 @@ export default {
   'page.discover.header.count': '{count} giriş bulundu',
   'page.discover.table.header.id': 'ID',
   'page.discover.table.header.author': 'Yazar',
+  'page.discover.table.header.author.email': 'E‑posta girilmedi',
   'page.discover.table.header.message': 'İleti',
   'page.discover.table.header.thread': 'Başlığı',
   'page.discover.table.header.entry': 'Giriş',

--- a/admin/src/translations/zh-Hans.ts
+++ b/admin/src/translations/zh-Hans.ts
@@ -27,6 +27,7 @@ export default {
   'page.discover.header.count': '{count} 找到的条目',
   'page.discover.table.header.id': 'ID',
   'page.discover.table.header.author': '作者',
+  'page.discover.table.header.author.email': '未填写电子邮件',
   'page.discover.table.header.message': '内容',
   'page.discover.table.header.thread': '线索的',
   'page.discover.table.header.entry': '入口',


### PR DESCRIPTION
## Ticket

https://github.com/VirtusLab/strapi-plugin-comments/issues/356

## Summary

The Discover threads page was empty even though that there were plenty of comments in database and all of them could be accessed with endpoints. I've changed e-mail to accept null values as it is only used to display tooltip in this view. 
Now all of the comments are visible, but when some of them have e-mail address missing, tooltip shows "E-mail not provided" instead of crashing all records.

<img width="1079" height="113" alt="Screenshot 2025-11-21 at 12 46 53" src="https://github.com/user-attachments/assets/71085ef4-5fb6-451b-b730-d28ddd7f7905" />

## Test Plan

Post a comment as an unauthenticated user (e.g. with graphql GetCreateComment) where author doesn't have e-mail address provided and then try to display this comment in Discover threads page in admin to check if the page isn't blank.
