### PR TITLE
fix blank comments page

### DIFF
--- a/admin/src/api/schemas.ts
+++ b/admin/src/api/schemas.ts
@@ -235,7 +235,7 @@ export const userSchema = z.object({
     id: z.number(),
     documentId: z.string(),
     firstname: z.string(),
-    lastname: z.string(),
+    lastname: z.string().nullable(),
     username: z.string().nullable(),
     email: z.string(),
     isActive: z.boolean(),


### PR DESCRIPTION
## Ticket

https://github.com/VirtusLab/strapi-plugin-comments/issues/348

## Summary

After the initial run of the plugin, both the comments page and the comments settings page were blank. This issue occurred because the database had not been initialized, which caused one of the values to return as null. I have allowed for this scenario, and now both pages are visible.


## Test Plan

During the initial run, you do not need to do anything extra; just execute the plugin and verify that both pages are visible.
To test it, if you already have the plugin installed, you need to remove the database with comments to enable its initial setup. 