### PR TITLE
Make select schema fields nullable, as they can be null when calling …

### DIFF
--- a/admin/src/api/schemas.ts
+++ b/admin/src/api/schemas.ts
@@ -218,9 +218,9 @@ const roleSchema = z.object({
   name: z.string(),
   code: z.string(),
   description: z.string(),
-  createdAt: z.string(),
-  updatedAt: z.string(),
-  publishedAt: z.string(),
+  createdAt: z.string().nullable(),
+  updatedAt: z.string().nullable(),
+  publishedAt: z.string().nullable(),
   locale: z.string().nullable(),
   usersCount: z.number(),
 });
@@ -239,11 +239,11 @@ export const userSchema = z.object({
     username: z.string().nullable(),
     email: z.string(),
     isActive: z.boolean(),
-    blocked: z.boolean(),
+    blocked: z.boolean().nullable(),
     preferedLanguage: z.string().nullable(),
-    createdAt: z.string(),
+    createdAt: z.string().nullable(),
     updatedAt: z.string(),
-    publishedAt: z.string(),
+    publishedAt: z.string().nullable(),
     locale: z.null(),
     roles: z.array(
       z.object({


### PR DESCRIPTION
…/admin/users/me

## Ticket

https://github.com/VirtusLab/strapi-plugin-comments/issues/378

## Summary

After this fix, the plugin pages will not be empty.

## Test Plan

Build plugin, add plugin to strapi >5.37.x, open admin interface, go to settings, go to Comments plugin configuration
