### PR TITLE
Fix: sets proper label and description for profanity toggler setting

### DIFF
--- a/admin/src/pages/Settings/index.tsx
+++ b/admin/src/pages/Settings/index.tsx
@@ -338,10 +338,10 @@ const Settings = () => {
                     <Grid.Item col={4} xs={12} alignItems="start">
                       <Field.Root
                         width="100%"
-                        hint={getMessage('page.settings.form.enabledCollections.hint')}
+                        hint={getMessage('page.settings.form.badWords.hint')}
                       >
-                        <Field.Label htmlFor="enabledCollections">
-                          {getMessage('page.settings.form.enabledCollections.label')}
+                        <Field.Label htmlFor="badWords">
+                          {getMessage('page.settings.form.badWords.label')}
                         </Field.Label>
                         <Toggle
                           name="badWords"


### PR DESCRIPTION
## Ticket

https://github.com/VirtusLab/strapi-plugin-comments/issues/405

## Summary

It changes label and description for profanity toggler in admin settings panel.

## Test Plan

Label and description is displaying proper values adequate to declared mechanism.
