### PR TITLE
Feat: Reactions plugin intergration

### DIFF
--- a/admin/src/api/schemas.ts
+++ b/admin/src/api/schemas.ts
@@ -148,7 +148,7 @@ export const commentsSchema = z.object({
 
 export const commentDetailsSchema = z.object({
   entity: relatedSchema,
-  selected: baseCommentSchema
+  selected: getCommentSchema()
     .merge(
       z.object({
         related: z.string(),

--- a/admin/src/api/schemas.ts
+++ b/admin/src/api/schemas.ts
@@ -5,6 +5,7 @@ export const configSchema = z.object({
   entryLabel: z.record(z.array(z.string())),
   approvalFlow: z.array(z.string()),
   blockedAuthorProps: z.array(z.string()),
+  reactionsEnabled: z.boolean(),
   reportReasons: z.record(z.string()),
   regex: z.object({
     uid: z.string(),
@@ -15,6 +16,7 @@ export const configSchema = z.object({
   enabledCollections: z.array(z.string()),
   moderatorRoles: z.array(z.string()),
   isGQLPluginEnabled: z.boolean(),
+  isReactionsPluginInstalled: z.boolean(),
   badWords: z.boolean().nullable().optional(),
   gql: z
     .object({

--- a/admin/src/api/schemas.ts
+++ b/admin/src/api/schemas.ts
@@ -138,7 +138,8 @@ const commentSchema: z.ZodType<Comment> = getCommentSchema();
 export type Comment = BaseComment & {
   threadOf?: Comment | null
   related?: z.infer<typeof relatedSchema> | string
-  documentId?: string
+  documentId?: string,
+  locale?: string | null
 };
 
 

--- a/admin/src/components/CommentReactionsSummary/index.tsx
+++ b/admin/src/components/CommentReactionsSummary/index.tsx
@@ -1,17 +1,12 @@
-import { FC } from 'react';
+import type { FC } from 'react';
 import { get, isEmpty } from 'lodash';
 import { Data } from '@strapi/strapi';
 import { Box, Divider, Grid, Typography } from '@strapi/design-system';
-import { useQuery } from '@tanstack/react-query';
-import { useFetchClient } from '@strapi/strapi/admin';
-
 import { ReactionCounter } from '../ReactionCounter';
 import { getMessage } from '../../utils';
-import {
-  fetchReactionCounts,
-  fetchReactionTypes,
-  ReactionType,
-} from '../../utils/reactionsIntegration';
+import { ReactionType } from '../../utils/reactionsIntegration';
+import { useReactionCounts } from '../../hooks/useReactionCounts';
+import { useReactionTypes } from '../../hooks/useReactionTypes';
 
 type CommentReactionsSummaryProps = {
   documentId?: Data.DocumentID;
@@ -22,20 +17,8 @@ export const CommentReactionsSummary: FC<CommentReactionsSummaryProps> = ({
   documentId,
   locale,
 }) => {
-  const fetchClient = useFetchClient();
-
-  const typesQuery = useQuery({
-    queryKey: ['comments-reactions-config'],
-    queryFn: () => fetchReactionTypes(fetchClient),
-    retry: false,
-  });
-
-  const countsQuery = useQuery({
-    queryKey: ['comments-reactions-counts', documentId, locale],
-    queryFn: () => fetchReactionCounts(documentId!, locale || undefined, fetchClient),
-    enabled: Boolean(documentId),
-    retry: false,
-  });
+  const typesQuery = useReactionTypes();
+  const countsQuery = useReactionCounts(documentId!, locale);
 
   if (typesQuery.isError || countsQuery.isError) {
     return null;

--- a/admin/src/components/CommentReactionsSummary/index.tsx
+++ b/admin/src/components/CommentReactionsSummary/index.tsx
@@ -9,7 +9,7 @@ import { useReactionCounts } from '../../hooks/useReactionCounts';
 import { useReactionTypes } from '../../hooks/useReactionTypes';
 
 type CommentReactionsSummaryProps = {
-  documentId?: Data.DocumentID;
+  documentId: Data.DocumentID;
   locale?: string | null;
 };
 
@@ -18,7 +18,7 @@ export const CommentReactionsSummary: FC<CommentReactionsSummaryProps> = ({
   locale,
 }) => {
   const typesQuery = useReactionTypes();
-  const countsQuery = useReactionCounts(documentId!, locale);
+  const countsQuery = useReactionCounts(documentId, locale);
 
   if (typesQuery.isError || countsQuery.isError) {
     return null;

--- a/admin/src/components/CommentReactionsSummary/index.tsx
+++ b/admin/src/components/CommentReactionsSummary/index.tsx
@@ -22,7 +22,6 @@ export const CommentReactionsSummary: FC<CommentReactionsSummaryProps> = ({
   documentId,
   locale,
 }) => {
-  console.log('CommentReactionsSummary', documentId, locale);
   const fetchClient = useFetchClient();
 
   const typesQuery = useQuery({

--- a/admin/src/components/CommentReactionsSummary/index.tsx
+++ b/admin/src/components/CommentReactionsSummary/index.tsx
@@ -1,0 +1,76 @@
+import { FC } from 'react';
+import { get, isEmpty } from 'lodash';
+import { Data } from '@strapi/strapi';
+import { Box, Divider, Grid, Typography } from '@strapi/design-system';
+import { useQuery } from '@tanstack/react-query';
+import { useFetchClient } from '@strapi/strapi/admin';
+
+import { ReactionCounter } from '../ReactionCounter';
+import { getMessage } from '../../utils';
+import {
+  fetchReactionCounts,
+  fetchReactionTypes,
+  ReactionType,
+} from '../../utils/reactionsIntegration';
+
+type CommentReactionsSummaryProps = {
+  documentId?: Data.DocumentID;
+  locale?: string | null;
+};
+
+export const CommentReactionsSummary: FC<CommentReactionsSummaryProps> = ({
+  documentId,
+  locale,
+}) => {
+  console.log('CommentReactionsSummary', documentId, locale);
+  const fetchClient = useFetchClient();
+
+  const typesQuery = useQuery({
+    queryKey: ['comments-reactions-config'],
+    queryFn: () => fetchReactionTypes(fetchClient),
+    retry: false,
+  });
+
+  const countsQuery = useQuery({
+    queryKey: ['comments-reactions-counts', documentId, locale],
+    queryFn: () => fetchReactionCounts(documentId!, locale || undefined, fetchClient),
+    enabled: Boolean(documentId),
+    retry: false,
+  });
+
+  if (typesQuery.isError || countsQuery.isError) {
+    return null;
+  }
+
+  const isLoading = typesQuery.isPending || countsQuery.isPending;
+  const types = typesQuery.data || [];
+  const reactionsCount = countsQuery.data || {};
+  const isNotRenderable = isLoading || isEmpty(reactionsCount) || isEmpty(types) || !documentId;
+
+  if (isNotRenderable) {
+    return null;
+  }
+
+  return (
+    <Box marginBottom={4}>
+      <Typography variant="sigma" textColor="neutral600" id="comment-reactions">
+        {getMessage('page.details.panel.reactions', 'Reactions')}
+      </Typography>
+      <Box paddingTop={2} paddingBottom={4}>
+        <Divider />
+      </Box>
+      <Grid.Root gap={4}>
+        {types.map(({ name, slug, icon, emoji }: ReactionType) => (
+          <Grid.Item key={`reaction-type-${slug}`} col={5} s={6} xs={12}>
+            <ReactionCounter
+              name={name}
+              icon={icon}
+              emoji={emoji}
+              count={get(reactionsCount, slug)}
+            />
+          </Grid.Item>
+        ))}
+      </Grid.Root>
+    </Box>
+  );
+};

--- a/admin/src/components/ReactionCounter/index.tsx
+++ b/admin/src/components/ReactionCounter/index.tsx
@@ -1,6 +1,7 @@
+import type { FC } from 'react';
 import { Tooltip } from '@strapi/design-system';
 import { usePluginTheme } from '@sensinum/strapi-utils';
-
+import type { ReactionType } from 'src/utils/reactionsIntegration';
 import {
   ReactionCounterContainer,
   ReactionCounterDot,
@@ -9,19 +10,11 @@ import {
   ReactionName,
 } from './styled';
 
-export type ReactionCounterProps = {
-  name: string;
-  icon?: { url?: string } | null;
-  emoji?: string | null;
+type ReactionCounterProps = Omit<ReactionType, 'slug'> & {
   count: number;
 };
 
-export const ReactionCounter = ({
-  name,
-  icon,
-  emoji,
-  count = 0,
-}: ReactionCounterProps) => {
+export const ReactionCounter: FC<ReactionCounterProps> = ({ name, icon, emoji, count = 0 }) => {
   const { theme } = usePluginTheme();
 
   return (

--- a/admin/src/components/ReactionCounter/index.tsx
+++ b/admin/src/components/ReactionCounter/index.tsx
@@ -1,0 +1,39 @@
+import { Tooltip } from '@strapi/design-system';
+import { usePluginTheme } from '@sensinum/strapi-utils';
+
+import {
+  ReactionCounterContainer,
+  ReactionCounterDot,
+  ReactionEmoji,
+  ReactionImage,
+  ReactionName,
+} from './styled';
+
+export type ReactionCounterProps = {
+  name: string;
+  icon?: { url?: string } | null;
+  emoji?: string | null;
+  count: number;
+};
+
+export const ReactionCounter = ({
+  name,
+  icon,
+  emoji,
+  count = 0,
+}: ReactionCounterProps) => {
+  const { theme } = usePluginTheme();
+
+  return (
+    <ReactionCounterContainer active>
+      {icon && <ReactionImage src={icon.url} />}
+      {!icon && <ReactionEmoji>{emoji}</ReactionEmoji>}
+      <ReactionName>
+        <Tooltip description={name}>
+          <span>{name}</span>
+        </Tooltip>
+      </ReactionName>
+      <ReactionCounterDot theme={theme}>{count}</ReactionCounterDot>
+    </ReactionCounterContainer>
+  );
+};

--- a/admin/src/components/ReactionCounter/styled.ts
+++ b/admin/src/components/ReactionCounter/styled.ts
@@ -1,0 +1,57 @@
+import styled from 'styled-components';
+
+import { Badge } from '@strapi/design-system';
+
+export const ReactionCounterContainer = styled(Badge)`
+  width: 100%;
+  cursor: default;
+
+  & > span {
+    display: inline-flex;
+    flex-direction: row;
+    align-items: center;
+    justify-content: stretch;
+    width: 100%;
+  }
+`;
+
+export const ReactionImage = styled.img`
+  display: inline-block;
+  max-width: 16px;
+  max-height: 16px;
+`;
+
+export const ReactionEmoji = styled.span`
+  display: inline-block;
+`;
+
+export const ReactionName = styled.span`
+  display: inline-flex;
+  flex-direction: column;
+  flex-grow: 1;
+  justify-content: flex-start;
+  max-height: 16px;
+  padding-left: 8px;
+  overflow: hidden;
+
+  span {
+    display: inline-block;
+    width: 100%;
+    text-align: left;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    overflow: hidden;
+  }
+`;
+
+export const ReactionCounterDot = styled.span<{ theme: string }>`
+  display: inline-flex;
+  margin-left: 8px;
+  align-content: center;
+  justify-content: center;
+  flex-wrap: wrap;
+  min-width: 16px;
+  height: 16px;
+  border-radius: 8px;
+  background: #ffffff;
+`;

--- a/admin/src/hooks/useReactionCounts.ts
+++ b/admin/src/hooks/useReactionCounts.ts
@@ -1,0 +1,22 @@
+import { useQuery } from '@tanstack/react-query';
+import { Data } from '@strapi/strapi';
+import { useFetchClient } from '@strapi/strapi/admin';
+import { fetchReactionCounts } from '../utils/reactionsIntegration';
+import { ValidationError } from '../utils/errors';
+
+export const useReactionCounts = (documentId: Data.DocumentID, locale?: string | null) => {
+  const { get } = useFetchClient();
+
+  return useQuery({
+    queryKey: ['comments-reactions-counts', documentId, locale],
+    queryFn: () => {
+      if (!documentId) {
+        throw new ValidationError('documentId is required to fetch reaction counts');
+      }
+
+      return fetchReactionCounts(documentId, locale || undefined, get);
+    },
+    enabled: Boolean(documentId),
+    retry: false,
+  });
+};

--- a/admin/src/hooks/useReactionCounts.ts
+++ b/admin/src/hooks/useReactionCounts.ts
@@ -2,7 +2,7 @@ import { useQuery } from '@tanstack/react-query';
 import { Data } from '@strapi/strapi';
 import { useFetchClient } from '@strapi/strapi/admin';
 import { fetchReactionCounts } from '../utils/reactionsIntegration';
-import { ValidationError } from '../utils/errors';
+import { assertNonEmpty } from 'src/utils/functions';
 
 export const useReactionCounts = (documentId: Data.DocumentID, locale?: string | null) => {
   const { get } = useFetchClient();
@@ -10,9 +10,7 @@ export const useReactionCounts = (documentId: Data.DocumentID, locale?: string |
   return useQuery({
     queryKey: ['comments-reactions-counts', documentId, locale],
     queryFn: () => {
-      if (!documentId) {
-        throw new ValidationError('documentId is required to fetch reaction counts');
-      }
+      assertNonEmpty<Data.DocumentID>(documentId);
 
       return fetchReactionCounts(documentId, locale || undefined, get);
     },

--- a/admin/src/hooks/useReactionTypes.ts
+++ b/admin/src/hooks/useReactionTypes.ts
@@ -1,0 +1,14 @@
+import { useQuery } from '@tanstack/react-query';
+import { useFetchClient } from '@strapi/strapi/admin';
+
+import { fetchReactionTypes } from '../utils/reactionsIntegration';
+
+export const useReactionTypes = () => {
+  const { get } = useFetchClient();
+
+  return useQuery({
+    queryKey: ['comments-reactions-config'],
+    queryFn: () => fetchReactionTypes(get),
+    retry: false,
+  });
+};

--- a/admin/src/pages/Details/DetailsEntry.tsx
+++ b/admin/src/pages/Details/DetailsEntry.tsx
@@ -56,7 +56,7 @@ export const DetailsEntry: FC<DetailsEntryProps> = ({
     <Box padding={4} background="neutral0" width="100%">
       <CommentReactionsSummary
         documentId={selected?.documentId}
-        locale={(selected as { locale?: string | null } | undefined)?.locale}
+        locale={selected?.locale}
       />
       {canEntityRender && (
         <Box marginBottom={4}>

--- a/admin/src/pages/Details/DetailsEntry.tsx
+++ b/admin/src/pages/Details/DetailsEntry.tsx
@@ -1,5 +1,4 @@
 import { Box, Divider, Flex, Typography, Checkbox } from '@strapi/design-system';
-import { useQueryClient } from '@tanstack/react-query';
 import { capitalize, first, isEmpty, isNil, take } from 'lodash';
 import { FC, useCallback } from 'react';
 import { Comment, CommentDetails, Config, ContentType } from '../../api/schemas';
@@ -25,7 +24,6 @@ export const DetailsEntry: FC<DetailsEntryProps> = ({
   const { entryLabel = {} } = config;
   const { attributes = {} } = schema;
   const { removed = false } = filters;
-  const queryClient = useQueryClient();
 
   const keys = Object.keys(attributes);
   const entityLabelKey = first(entryLabel[entity?.uid]);

--- a/admin/src/pages/Details/DetailsEntry.tsx
+++ b/admin/src/pages/Details/DetailsEntry.tsx
@@ -2,17 +2,26 @@ import { Box, Divider, Flex, Typography, Checkbox } from '@strapi/design-system'
 import { useQueryClient } from '@tanstack/react-query';
 import { capitalize, first, isEmpty, isNil, take } from 'lodash';
 import { FC, useCallback } from 'react';
-import { CommentDetails, Config, ContentType } from '../../api/schemas';
+import { Comment, CommentDetails, Config, ContentType } from '../../api/schemas';
+import { CommentReactionsSummary } from '../../components/CommentReactionsSummary';
 import { getMessage } from '../../utils';
 
 type DetailsEntryProps = {
   readonly config: Config;
   readonly entity: CommentDetails['entity'];
+  readonly selected?: Comment | null;
   readonly filters: Record<string, unknown>;
   readonly onChangeFilters: (filters: Record<string, unknown>) => void;
   readonly schema: ContentType['data']['schema'];
 };
-export const DetailsEntry: FC<DetailsEntryProps> = ({ config, entity, filters, onChangeFilters, schema }) => {
+export const DetailsEntry: FC<DetailsEntryProps> = ({
+  config,
+  entity,
+  selected,
+  filters,
+  onChangeFilters,
+  schema,
+}) => {
   const { entryLabel = {} } = config;
   const { attributes = {} } = schema;
   const { removed = false } = filters;
@@ -45,6 +54,11 @@ export const DetailsEntry: FC<DetailsEntryProps> = ({ config, entity, filters, o
 
   return (
     <Box padding={4} background="neutral0" width="100%">
+      <CommentReactionsSummary
+        documentId={selected?.documentId}
+        // documentId={"j3p4fbz5dgnowsks98h4wxqg"}
+        locale={(selected as { locale?: string | null } | undefined)?.locale}
+      />
       {canEntityRender && (
         <Box marginBottom={4}>
           <Typography

--- a/admin/src/pages/Details/DetailsEntry.tsx
+++ b/admin/src/pages/Details/DetailsEntry.tsx
@@ -56,7 +56,6 @@ export const DetailsEntry: FC<DetailsEntryProps> = ({
     <Box padding={4} background="neutral0" width="100%">
       <CommentReactionsSummary
         documentId={selected?.documentId}
-        // documentId={"j3p4fbz5dgnowsks98h4wxqg"}
         locale={(selected as { locale?: string | null } | undefined)?.locale}
       />
       {canEntityRender && (

--- a/admin/src/pages/Details/index.tsx
+++ b/admin/src/pages/Details/index.tsx
@@ -89,6 +89,7 @@ export const Details: FC<{ config: Config }> = ({ config }) => {
                 <DetailsEntry
                   config={config}
                   entity={entity}
+                  selected={selected}
                   filters={filters}
                   onChangeFilters={setFilters}
                   schema={contentTypeData?.schema || ({ attributes: {} } as any)}

--- a/admin/src/pages/Settings/index.tsx
+++ b/admin/src/pages/Settings/index.tsx
@@ -93,6 +93,7 @@ const Settings = () => {
       updateSettingsMutation.mutate({
         ...values,
         blockedAuthorProps: values.blockedAuthorProps.split(',').map((prop: string) => prop.trim()),
+        reactionsEnabled: values.reactionsEnabled,
       });
     },
     [updateSettingsMutation]
@@ -120,6 +121,7 @@ const Settings = () => {
   const clientUrl = config.data.client?.url;
   const clientEmail = config.data.client?.contactEmail;
   const blockedAuthorProps = config.data.blockedAuthorProps ?? [];
+  const reactionsEnabled = config.data.reactionsEnabled ?? false;
   const onDiscardRestart = () => setIsRestartRequired(false);
 
   return (
@@ -183,6 +185,7 @@ const Settings = () => {
               approvalFlow: config.data.approvalFlow,
               entryLabel: config.data.entryLabel,
               blockedAuthorProps: blockedAuthorProps.join(', '),
+              reactionsEnabled,
             }}
           >
             {({ values, onChange }) => (
@@ -384,6 +387,27 @@ const Settings = () => {
                         <Field.Hint />
                       </Field.Root>
                     </Grid.Item>
+                    <RenderIf condition={config.data.isReactionsPluginInstalled}>
+                      <Grid.Item col={4} xs={12} alignItems="start">
+                        <Field.Root
+                          width="100%"
+                          hint={getMessage('page.settings.form.reactionsEnabled.hint')}
+                        >
+                          <Field.Label>
+                            {getMessage('page.settings.form.reactionsEnabled.label')}
+                          </Field.Label>
+                          <Toggle
+                            name="reactionsEnabled"
+                            checked={values.reactionsEnabled}
+                            onChange={onChange}
+                            onLabel={getMessage('components.toogle.enabled')}
+                            offLabel={getMessage('components.toogle.disabled')}
+                            width="100%"
+                          />
+                          <Field.Hint />
+                        </Field.Root>
+                      </Grid.Item>
+                    </RenderIf>
                   </Grid.Root>
                 </Box>
                 <Box {...boxDefaultProps}>

--- a/admin/src/store/settings.store.ts
+++ b/admin/src/store/settings.store.ts
@@ -26,6 +26,7 @@ export const useSettingsStore = create<SettingsStore>((set) => ({
     enabledCollections: [],
     moderatorRoles: [],
     isGQLPluginEnabled: false,
+    isReactionsPluginInstalled: false,
     client: {
       url: '',
       contactEmail: '',

--- a/admin/src/store/settings.store.ts
+++ b/admin/src/store/settings.store.ts
@@ -11,6 +11,7 @@ export const useSettingsStore = create<SettingsStore>((set) => ({
     entryLabel: {},
     approvalFlow: [],
     blockedAuthorProps: [],
+    reactionsEnabled: false,
     reportReasons: {
       BAD_LANGUAGE: 'BAD_LANGUAGE',
       DISCRIMINATION: 'DISCRIMINATION',

--- a/admin/src/translations/en.ts
+++ b/admin/src/translations/en.ts
@@ -157,6 +157,9 @@ const en = {
   'page.settings.form.gqlAuth.label': 'GraphQL queries authorization',
   'page.settings.form.gqlAuth.hint':
     'If enabled, GraphQL API queries & mutations can be triggered only by Authenticated Strapi users. Otherwise API remains open.',
+  'page.settings.form.reactionsEnabled.label': 'Reactions integration',
+  'page.settings.form.reactionsEnabled.hint':
+    'If enabled, comment responses in REST and GraphQL APIs include reaction counts. Requires the Reactions plugin to be installed and enabled.',
   'page.settings.form.approvalFlow.label': 'Approval flow',
   'page.settings.form.approvalFlow.hint':
     'Comments associated with content type "{name}" are going to be taken through manual approval flow',

--- a/admin/src/translations/fr.ts
+++ b/admin/src/translations/fr.ts
@@ -164,6 +164,9 @@ export default {
   'page.settings.form.gqlAuth.label': 'Autorisation des requêtes GraphQL',
   'page.settings.form.gqlAuth.hint':
     "Si activé, les requêtes et mutations de l'API GraphQL ne peuvent être déclenchées que par les utilisateurs Strapi authentifiés. Sinon, l'API reste ouverte.",
+  'page.settings.form.reactionsEnabled.label': 'Intégration des réactions',
+  'page.settings.form.reactionsEnabled.hint':
+    "Si activé, les réponses API des commentaires (REST et GraphQL) incluent les compteurs de réactions. Nécessite que le plugin Reactions soit installé et activé.",
   'page.settings.form.approvalFlow.label': 'Flux de validation',
   'page.settings.form.approvalFlow.hint':
     'Les commentaires associés au type de contenu « {nom} » seront soumis à un flux de vérification manuel',

--- a/admin/src/translations/pl.ts
+++ b/admin/src/translations/pl.ts
@@ -158,9 +158,9 @@ export default {
   'page.settings.form.gqlAuth.label': 'Autoryzacja zapytań GraphQL',
   'page.settings.form.gqlAuth.hint':
     'Jeśli jest włączone, zapytania i mutacje interfejsu API GraphQL mogą być wywoływane tylko przez uwierzytelnionych użytkowników Strapi. W przeciwnym razie API pozostaje otwarte.',
-  'page.settings.form.reactionsEnabled.label': 'Integracja reakcji',
+  'page.settings.form.reactionsEnabled.label': 'Integracja z pluginem Reakcji',
   'page.settings.form.reactionsEnabled.hint':
-    'Po włączeniu odpowiedzi API komentarzy (REST i GraphQL) zawierają liczniki reakcji. Wymaga zainstalowanego i włączonego pluginu Reactions.',
+    'Po włączeniu odpowiedzi API komentarzy (REST i GraphQL) zawierają liczniki reakcji. Wymaga zainstalowanego i włączonego pluginu Reakcji.',
   'page.settings.form.approvalFlow.label': 'Przebieg zatwierdzania',
   'page.settings.form.approvalFlow.hint':
     'Komentarze powiązane z typem zawartości "{name}" będą podlegały ręcznemu procesowi zatwierdzania',

--- a/admin/src/translations/pl.ts
+++ b/admin/src/translations/pl.ts
@@ -158,6 +158,9 @@ export default {
   'page.settings.form.gqlAuth.label': 'Autoryzacja zapytań GraphQL',
   'page.settings.form.gqlAuth.hint':
     'Jeśli jest włączone, zapytania i mutacje interfejsu API GraphQL mogą być wywoływane tylko przez uwierzytelnionych użytkowników Strapi. W przeciwnym razie API pozostaje otwarte.',
+  'page.settings.form.reactionsEnabled.label': 'Integracja reakcji',
+  'page.settings.form.reactionsEnabled.hint':
+    'Po włączeniu odpowiedzi API komentarzy (REST i GraphQL) zawierają liczniki reakcji. Wymaga zainstalowanego i włączonego pluginu Reactions.',
   'page.settings.form.approvalFlow.label': 'Przebieg zatwierdzania',
   'page.settings.form.approvalFlow.hint':
     'Komentarze powiązane z typem zawartości "{name}" będą podlegały ręcznemu procesowi zatwierdzania',

--- a/admin/src/translations/pt-BR.ts
+++ b/admin/src/translations/pt-BR.ts
@@ -131,6 +131,9 @@ export default {
   'page.settings.form.gqlAuth.label': 'GraphQL queries authorization',
   'page.settings.form.gqlAuth.hint':
     'Se ativado, as queries e mutations da API GraphQL podem ser acionadas apenas por usuários autenticados do Strapi. Caso contrário, a API permanece aberta.',
+  'page.settings.form.reactionsEnabled.label': 'Integração de reações',
+  'page.settings.form.reactionsEnabled.hint':
+    'Se ativado, as respostas da API de comentários (REST e GraphQL) incluem contadores de reações. Requer o plugin Reactions instalado e ativado.',
   'page.settings.form.approvalFlow.label': 'Fluxo de aprovação',
   'page.settings.form.approvalFlow.hint':
     'Os comentários associados ao tipo de conteúdo "{name}" passarão pelo fluxo de aprovação manual',

--- a/admin/src/translations/ru.ts
+++ b/admin/src/translations/ru.ts
@@ -156,6 +156,9 @@ export default {
   'page.settings.form.gqlAuth.label': 'Авторизация запросов GraphQL',
   'page.settings.form.gqlAuth.hint':
     'If enabled, GraphQL API queries & mutations can be triggered only by Authenticated Strapi users. Otherwise API remains open.',
+  'page.settings.form.reactionsEnabled.label': 'Интеграция реакций',
+  'page.settings.form.reactionsEnabled.hint':
+    'Если включено, ответы API комментариев (REST и GraphQL) содержат счётчики реакций. Требуется установленный и включённый плагин Reactions.',
   'page.settings.form.approvalFlow.label': 'Бизнес-процесс согласования',
   'page.settings.form.approvalFlow.hint':
     'Комментарии, связанные с типом контента "{name}", будут проведены через ручной бизнес-процесс согласования',

--- a/admin/src/translations/tr.ts
+++ b/admin/src/translations/tr.ts
@@ -156,6 +156,9 @@ export default {
   'page.settings.form.gqlAuth.label': 'GraphQL Sorgu Yetkileri',
   'page.settings.form.gqlAuth.hint':
     'Etkinse, GraphQL API sorguları ve mutasyonları yalnızca kimliği doğrulanmış Strapi kullanıcıları tarafından tetiklenebilir. Aksi takdirde API açık kalır.',
+  'page.settings.form.reactionsEnabled.label': 'Tepki entegrasyonu',
+  'page.settings.form.reactionsEnabled.hint':
+    'Etkinleştirildiğinde, yorum API yanıtları (REST ve GraphQL) tepki sayılarını içerir. Reactions eklentisinin kurulu ve etkin olması gerekir.',
   'page.settings.form.approvalFlow.label': 'Onay akışı',
   'page.settings.form.approvalFlow.hint':
     'İçerik türü "{name}" ile ilişkili yorumlar manuel onay akışı yoluyla alınacak',

--- a/admin/src/translations/zh-Hans.ts
+++ b/admin/src/translations/zh-Hans.ts
@@ -149,6 +149,9 @@ export default {
   'page.settings.form.gqlAuth.label': 'GraphQL查询授权',
   'page.settings.form.gqlAuth.hint':
     '如果启用， GraphQL API queries 和 mutations 只能由经过身份验证的 Strapi 用户触发。否则 API 将保持打开状态。',
+  'page.settings.form.reactionsEnabled.label': '反应集成',
+  'page.settings.form.reactionsEnabled.hint':
+    '启用后，评论 API 响应（REST 和 GraphQL）将包含反应计数。需要安装并启用 Reactions 插件。',
   'page.settings.form.approvalFlow.label': '审批流程',
   'page.settings.form.approvalFlow.hint':
     '与Content Type "{name}" 关联的评论将通过手动审批流程获取',

--- a/admin/src/utils/__tests__/functions.test.ts
+++ b/admin/src/utils/__tests__/functions.test.ts
@@ -1,4 +1,4 @@
-import { assertString } from "../functions";
+import { assertNonEmpty, assertString } from "../functions";
 
 describe("assertString()", () => {
   it("should allow strings", () => {
@@ -11,5 +11,16 @@ describe("assertString()", () => {
     expect(() => assertString(undefined)).toThrow();
     expect(() => assertString({})).toThrow();
     expect(() => assertString(new Error("Error"))).toThrow();
+  });
+});
+
+describe("assertNonEmpty()", () => {
+  it("should allow non-empty values", () => {
+    expect(() => assertNonEmpty("Content")).not.toThrow();
+  });
+
+  it("should reject empty values", () => {
+    expect(() => assertNonEmpty(null)).toThrow();
+    expect(() => assertNonEmpty(undefined)).toThrow();
   });
 });

--- a/admin/src/utils/functions.ts
+++ b/admin/src/utils/functions.ts
@@ -1,7 +1,15 @@
 import { ValidationError } from "./errors";
 
+type NonEmpty<T> = T extends null | undefined ? never : T;
+
 export function assertString(value: unknown): asserts value is string {
   if (typeof value !== "string") {
     throw new ValidationError(`String expected, but "${typeof value}" given`);
+  }
+}
+
+export function assertNonEmpty<T>(value: unknown, error = new Error('Value is empty')): asserts value is NonEmpty<T> {
+  if (value === null || value === undefined) {
+    throw error;
   }
 }

--- a/admin/src/utils/reactionsIntegration.ts
+++ b/admin/src/utils/reactionsIntegration.ts
@@ -1,0 +1,33 @@
+import qs from 'qs';
+import { Data } from '@strapi/strapi';
+
+type FetchClient = {
+  get: (url: string) => Promise<{ data: unknown }>;
+};
+
+export type ReactionType = {
+  slug: string;
+  name: string;
+  emoji?: string | null;
+  icon?: { url?: string } | null;
+};
+
+export type ReactionCounts = Record<string, number>;
+
+export const fetchReactionTypes = async ({ get }: FetchClient) => {
+  const { data } = await get(`/reactions/settings/config`);
+  return (data as { types?: Array<ReactionType> })?.types || [];
+};
+
+export const fetchReactionCounts = async (
+  documentId: Data.DocumentID,
+  locale: string | undefined,
+  { get }: FetchClient
+): Promise<ReactionCounts> => {
+  const query = qs.stringify({ locale });
+  const { data } = await get(
+    `/reactions/zone/count/plugin::comments.comment/${documentId}${query ? `?${query}` : ''}`
+  );
+
+  return (data as ReactionCounts) || {};
+};

--- a/admin/src/utils/reactionsIntegration.ts
+++ b/admin/src/utils/reactionsIntegration.ts
@@ -1,33 +1,56 @@
 import qs from 'qs';
+import { z } from 'zod';
 import { Data } from '@strapi/strapi';
+import { ValidationError } from './errors';
+import type { FetchClient } from '@strapi/strapi/admin';
 
-type FetchClient = {
-  get: (url: string) => Promise<{ data: unknown }>;
+const reactionTypeSchema = z.object({
+  slug: z.string(),
+  name: z.string(),
+  emoji: z.string().nullable().optional(),
+  icon: z
+    .object({
+      url: z.string().optional(),
+    })
+    .nullable()
+    .optional(),
+});
+
+const reactionsConfigSchema = z.object({
+  types: z.array(reactionTypeSchema).default([]),
+});
+
+const reactionCountsSchema = z.record(z.string(), z.number());
+
+export type ReactionType = z.infer<typeof reactionTypeSchema>;
+export type ReactionCounts = z.infer<typeof reactionCountsSchema>;
+
+const parseResponse = <T>(schema: z.ZodType<T>, data: unknown, context: string): T => {
+  const result = schema.safeParse(data);
+
+  if (!result.success) {
+    throw new ValidationError(`Invalid ${context}: ${result.error.message}`);
+  }
+
+  return result.data;
 };
 
-export type ReactionType = {
-  slug: string;
-  name: string;
-  emoji?: string | null;
-  icon?: { url?: string } | null;
-};
-
-export type ReactionCounts = Record<string, number>;
-
-export const fetchReactionTypes = async ({ get }: FetchClient) => {
+export const fetchReactionTypes = async (get: FetchClient['get']) => {
   const { data } = await get(`/reactions/settings/config`);
-  return (data as { types?: Array<ReactionType> })?.types || [];
+  const { types } = parseResponse(reactionsConfigSchema, data, 'reactions types');
+
+  return types;
 };
 
 export const fetchReactionCounts = async (
   documentId: Data.DocumentID,
-  locale: string | undefined,
-  { get }: FetchClient
-): Promise<ReactionCounts> => {
+  locale: string | null | undefined,
+  get: FetchClient['get']
+) => {
   const query = qs.stringify({ locale });
   const { data } = await get(
     `/reactions/zone/count/plugin::comments.comment/${documentId}${query ? `?${query}` : ''}`
   );
 
-  return (data as ReactionCounts) || {};
+  return parseResponse(reactionCountsSchema, data, 'reaction counts');
 };

--- a/server/src/config/index.ts
+++ b/server/src/config/index.ts
@@ -16,6 +16,7 @@ const defaultPluginConfig: CommentsPluginConfig = {
     OTHER: REPORT_REASON.OTHER,
   },
   blockedAuthorProps: [],
+  reactionsEnabled: true,
 };
 
 const reportReasonsSchema = z.object({
@@ -28,12 +29,14 @@ export const schemaConfig = z.object({
   isValidationEnabled: z.boolean().optional(),
   reportReasons: reportReasonsSchema.optional(),
   isGQLPluginEnabled: z.boolean().optional(),
+  isReactionsPluginInstalled: z.boolean().optional(),
   [CONFIG_PARAMS.ENABLED_COLLECTIONS]: z.array(z.string()),
   [CONFIG_PARAMS.MODERATOR_ROLES]: z.array(z.string()),
   [CONFIG_PARAMS.APPROVAL_FLOW]: z.array(z.string()),
   [CONFIG_PARAMS.ENTRY_LABEL]: z.record(z.array(z.string())),
   [CONFIG_PARAMS.BAD_WORDS]: z.boolean().optional(),
   [CONFIG_PARAMS.AUTHOR_BLOCKED_PROPS]: z.array(z.string()),
+  [CONFIG_PARAMS.REACTIONS_ENABLED]: z.boolean(),
   gql: z.object({
     auth: z.boolean().optional(),
   }).optional(),

--- a/server/src/graphql/queries/findAllFlat.ts
+++ b/server/src/graphql/queries/findAllFlat.ts
@@ -22,7 +22,7 @@ export default (strapi: CoreStrapi, nexus: Nexus) => {
     },
     async resolve(obj: Object, args) {
       const { relation, filters, sort, pagination } = args;
-      return await getPluginService(strapi, 'common').findAllFlat(
+      const response = await getPluginService(strapi, 'common').findAllFlat(
         flatInput({
           relation,
           filters: getPluginService(strapi, 'gql').graphQLFiltersToStrapiQuery(filters, contentType),
@@ -31,6 +31,14 @@ export default (strapi: CoreStrapi, nexus: Nexus) => {
         }),
         undefined,
       );
+
+      return {
+        data: response.data,
+        pagination: response.pagination,
+        meta: {
+          reactions: response.meta?.reactions,
+        },
+      };
     },
   };
 };

--- a/server/src/graphql/types/getComment.ts
+++ b/server/src/graphql/types/getComment.ts
@@ -15,6 +15,15 @@ export const getComment = (nexus: Nexus) => {
         t.field("author", { type: "CommentAuthor" });
         t.string("createdAt");
         t.string("updatedAt");
+        t.list.field("reactions", {
+          type: "CommentReactionCount",
+          resolve(parent: { reactions?: Record<string, number> }) {
+            return Object.entries(parent.reactions || {}).map(([slug, count]) => ({
+              slug,
+              count,
+            }));
+          },
+        });
     },
   });
 };

--- a/server/src/graphql/types/getCommentNested.ts
+++ b/server/src/graphql/types/getCommentNested.ts
@@ -16,6 +16,15 @@ export const getCommentNested = (nexus: Nexus) => {
       t.field('author', { type: 'CommentAuthor' });
       t.string('createdAt');
       t.string('updatedAt');
+      t.list.field('reactions', {
+        type: 'CommentReactionCount',
+        resolve(parent: { reactions?: Record<string, number> }) {
+          return Object.entries(parent.reactions || {}).map(([slug, count]) => ({
+            slug,
+            count,
+          }));
+        },
+      });
     },
   });
 };

--- a/server/src/graphql/types/getCommentReactionCount.ts
+++ b/server/src/graphql/types/getCommentReactionCount.ts
@@ -1,0 +1,11 @@
+import { Nexus } from '../../@types/graphql';
+
+export const getCommentReactionCount = (nexus: Nexus) => {
+  return nexus.objectType({
+    name: 'CommentReactionCount',
+    definition(t) {
+      t.nonNull.string('slug');
+      t.nonNull.int('count');
+    },
+  });
+};

--- a/server/src/graphql/types/getCommentReactionsMetaEntry.ts
+++ b/server/src/graphql/types/getCommentReactionsMetaEntry.ts
@@ -1,0 +1,11 @@
+import { Nexus } from '../../@types/graphql';
+
+export const getCommentReactionsMetaEntry = (nexus: Nexus) => {
+  return nexus.objectType({
+    name: 'CommentReactionsMetaEntry',
+    definition(t) {
+      t.nonNull.string('documentId');
+      t.nonNull.list.field('counts', { type: 'CommentReactionCount' });
+    },
+  });
+};

--- a/server/src/graphql/types/getResponseMeta.ts
+++ b/server/src/graphql/types/getResponseMeta.ts
@@ -1,10 +1,22 @@
 import { Nexus } from '../../@types/graphql';
 
+const mapReactionsMetaToEntries = (reactions: Record<string, Record<string, number>> = {}) =>
+  Object.entries(reactions).map(([documentId, counts]) => ({
+    documentId,
+    counts: Object.entries(counts).map(([slug, count]) => ({ slug, count })),
+  }));
+
 export const getResponseMeta = (nexus: Nexus) => {
     return nexus.objectType({
         name: "ResponseMeta",
         definition(t) {
             t.field("pagination", { type: "ResponsePagination" });
+            t.list.field("reactions", {
+              type: "CommentReactionsMetaEntry",
+              resolve(parent: { reactions?: Record<string, Record<string, number>> }) {
+                return mapReactionsMetaToEntries(parent.reactions);
+              },
+            });
         },
     });
 };

--- a/server/src/graphql/types/index.ts
+++ b/server/src/graphql/types/index.ts
@@ -4,6 +4,8 @@ import { getComment } from './getComment';
 import { getCommentAuthor } from './getCommentAuthor';
 import { getCommentAuthorType } from './getCommentAuthorType';
 import { getCommentNested } from './getCommentNested';
+import { getCommentReactionCount } from './getCommentReactionCount';
+import { getCommentReactionsMetaEntry } from './getCommentReactionsMetaEntry';
 import { getCreateComment } from './getCreateComment';
 import { getCreateCommentAuthor } from './getCreateCommentAuthor';
 import { getCreateReport } from './getCreateReport';
@@ -28,6 +30,8 @@ const typesFactories = [
   getCommentAuthor,
   getCommentAuthorType,
   getCommentNested,
+  getCommentReactionCount,
+  getCommentReactionsMetaEntry,
   getCreateComment,
   getCreateCommentAuthor,
   getCreateReport,

--- a/server/src/repositories/__tests__/store.repository.test.ts
+++ b/server/src/repositories/__tests__/store.repository.test.ts
@@ -93,6 +93,19 @@ describe('Store repository', () => {
       });
     });
 
+    it('includes isReactionsPluginInstalled as false when reactions plugin is not installed', async () => {
+      const strapi = getStrapi();
+      const mockConfig = { entryLabel: 'test', approvalFlow: true };
+      mockStore.get.mockResolvedValue(mockConfig);
+      caster<jest.Mock>(strapi.plugin).mockImplementation((name: string) =>
+        name === 'graphql' ? { kind: 'plugin' } : undefined,
+      );
+
+      const result = await getRepository(strapi).get(true);
+
+      expect(result.right).toHaveProperty('isReactionsPluginInstalled', false);
+    });
+
     it('returns local config when store is empty', async () => {
       const strapi = getStrapi();
       mockStore.get.mockResolvedValue(null);
@@ -116,11 +129,14 @@ describe('Store repository', () => {
     it('includes additional fields when viaSettingsPage is true', async () => {
       const strapi = getStrapi();
       mockStore.get.mockResolvedValue(null);
-      caster<jest.Mock>(strapi.plugin).mockReturnValue(true); // Mock graphql plugin enabled
+      caster<jest.Mock>(strapi.plugin).mockImplementation((name: string) =>
+        name === 'graphql' || name === 'reactions' ? true : undefined,
+      );
 
       const result = await getRepository(strapi).get(true);
 
       expect(result.right).toHaveProperty('isGQLPluginEnabled', true);
+      expect(result.right).toHaveProperty('isReactionsPluginInstalled', true);
       expect(result.right).toHaveProperty('enabledCollections');
       expect(result.right).toHaveProperty('moderatorRoles');
     });
@@ -233,6 +249,7 @@ describe('Store repository', () => {
           enabledCollections: ['api::article.article'],
           moderatorRoles: ['authenticated'],
           isGQLPluginEnabled: true,
+          isReactionsPluginInstalled: true,
           regex: expect.any(Object),
         });
       });

--- a/server/src/repositories/store.repository.ts
+++ b/server/src/repositories/store.repository.ts
@@ -22,7 +22,7 @@ export const getStoreRepositorySource = (strapi: CoreStrapi) => {
     async get<T extends boolean>(
       viaSettingsPage?: T,
     ): Promise<
-      Either<unknown, T extends true ? CommentsPluginConfig : Omit<CommentsPluginConfig, 'enabledCollections' | 'moderatorRoles' | 'isGQLPluginEnabled'>>
+      Either<unknown, T extends true ? CommentsPluginConfig : Omit<CommentsPluginConfig, 'enabledCollections' | 'moderatorRoles' | 'isGQLPluginEnabled' | 'isReactionsPluginInstalled'>>
     > {
       const config = await this.getConfig();
       const additionalConfiguration = {
@@ -37,6 +37,7 @@ export const getStoreRepositorySource = (strapi: CoreStrapi) => {
         ),
       };
       const isGQLPluginEnabled = !!strapi.plugin('graphql');
+      const reactionsPluginInstalled = !!strapi.plugin('reactions');
       const reportReasons = this.getLocalConfig('reportReasons');
       if (config) {
         // TODO: add report reasons to config page
@@ -45,6 +46,7 @@ export const getStoreRepositorySource = (strapi: CoreStrapi) => {
           ...additionalConfiguration,
           reportReasons,
           isGQLPluginEnabled: viaSettingsPage ? isGQLPluginEnabled : undefined,
+          isReactionsPluginInstalled: viaSettingsPage ? reactionsPluginInstalled : undefined,
         });
       }
       const entryLabel = this.getLocalConfig('entryLabel');
@@ -67,10 +69,11 @@ export const getStoreRepositorySource = (strapi: CoreStrapi) => {
           enabledCollections,
           moderatorRoles,
           isGQLPluginEnabled,
+          isReactionsPluginInstalled: reactionsPluginInstalled,
         });
       }
 
-      return makeRight(result) as unknown as Either<unknown, T extends true ? CommentsPluginConfig : Omit<CommentsPluginConfig, 'enabledCollections' | 'moderatorRoles' | 'isGQLPluginEnabled'>>;
+      return makeRight(result) as unknown as Either<unknown, T extends true ? CommentsPluginConfig : Omit<CommentsPluginConfig, 'enabledCollections' | 'moderatorRoles' | 'isGQLPluginEnabled' | 'isReactionsPluginInstalled'>>;
     },
     async update(config: CommentsPluginConfig) {
       const pluginStore = await this.getStore();

--- a/server/src/repositories/store.repository.ts
+++ b/server/src/repositories/store.repository.ts
@@ -37,7 +37,7 @@ export const getStoreRepositorySource = (strapi: CoreStrapi) => {
         ),
       };
       const isGQLPluginEnabled = !!strapi.plugin('graphql');
-      const reactionsPluginInstalled = !!strapi.plugin('reactions');
+      const isReactionsPluginInstalled = !!strapi.plugin('reactions');
       const reportReasons = this.getLocalConfig('reportReasons');
       if (config) {
         // TODO: add report reasons to config page
@@ -46,7 +46,7 @@ export const getStoreRepositorySource = (strapi: CoreStrapi) => {
           ...additionalConfiguration,
           reportReasons,
           isGQLPluginEnabled: viaSettingsPage ? isGQLPluginEnabled : undefined,
-          isReactionsPluginInstalled: viaSettingsPage ? reactionsPluginInstalled : undefined,
+          isReactionsPluginInstalled: viaSettingsPage ? isReactionsPluginInstalled : undefined,
         });
       }
       const entryLabel = this.getLocalConfig('entryLabel');
@@ -69,7 +69,7 @@ export const getStoreRepositorySource = (strapi: CoreStrapi) => {
           enabledCollections,
           moderatorRoles,
           isGQLPluginEnabled,
-          isReactionsPluginInstalled: reactionsPluginInstalled,
+          isReactionsPluginInstalled,
         });
       }
 

--- a/server/src/services/__tests__/admin.service.test.ts
+++ b/server/src/services/__tests__/admin.service.test.ts
@@ -61,11 +61,21 @@ describe('admin.service', () => {
     delete: jest.fn(),
   };
 
+  const mockReactionsService = {
+    removeForComments: jest.fn().mockResolvedValue(undefined),
+  };
+
   const mockFindOne = jest.fn();
 
   beforeEach(() => {
     jest.clearAllMocks();
-    caster<jest.Mock>(getPluginService).mockReturnValue(mockCommonService);
+    caster<jest.Mock>(getPluginService).mockImplementation((_strapi, name: string) => {
+      if (name === 'reactions') {
+        return mockReactionsService;
+      }
+
+      return mockCommonService;
+    });
     caster<jest.Mock>(getCommentRepository).mockReturnValue(mockCommentRepository);
     caster<jest.Mock>(getReportCommentRepository).mockReturnValue(mockReportCommentRepository);
     caster<jest.Mock>(getDefaultAuthorPopulate).mockReturnValue(true);
@@ -862,6 +872,28 @@ describe('admin.service', () => {
         where: { id: 1 },
         data: { removed: true },
       });
+    });
+
+    it('should remove reactions when deleted comment has documentId', async () => {
+      const strapi = getStrapi();
+      const service = getService(strapi);
+
+      mockCommentRepository.findOne.mockResolvedValue({
+        id: 1,
+        documentId: 'doc-1',
+        locale: 'en',
+        removed: false,
+      });
+      mockCommentRepository.update.mockResolvedValue({
+        id: 1,
+        documentId: 'doc-1',
+        locale: 'en',
+        removed: true,
+      });
+
+      await service.deleteComment(1);
+
+      expect(mockReactionsService.removeForComments).toHaveBeenCalledWith(['doc-1'], 'en');
     });
 
     it('should handle non-existent comment', async () => {

--- a/server/src/services/__tests__/client.service.test.ts
+++ b/server/src/services/__tests__/client.service.test.ts
@@ -42,6 +42,7 @@ describe('client.service', () => {
     findOne: jest.fn(),
     sanitizeCommentEntity: jest.fn(),
     sanitizeCommentContent: jest.fn((content: string) => content),
+    modifiedNestedNestedComments: jest.fn(),
   };
 
   const mockCommentRepository = {
@@ -294,6 +295,109 @@ describe('client.service', () => {
         PluginError
       );
     });
+
+    it('should throw error when threadOf does not exist', async () => {
+      const strapi = getStrapi();
+      const service = getService(strapi);
+
+      mockCommonService.parseRelationString.mockReturnValue({
+        uid: 'api::test.test',
+        relatedId: '1',
+      });
+      mockFindOne.mockResolvedValue({ id: 1 });
+      mockCommonService.getConfig.mockResolvedValue([]);
+      mockCommonService.isValidUserContext.mockReturnValue(true);
+      mockCommonService.findOne.mockRejectedValue(new Error('Not found'));
+
+      await expect(
+        service.create({ ...mockPayload, threadOf: 99 }, mockUser),
+      ).rejects.toMatchObject({
+        status: 400,
+        message: 'Thread does not exist',
+      });
+    });
+
+    it('should throw error when author data is incomplete', async () => {
+      const strapi = getStrapi();
+      const service = getService(strapi);
+
+      mockCommonService.parseRelationString.mockReturnValue({
+        uid: 'api::test.test',
+        relatedId: '1',
+      });
+      mockFindOne.mockResolvedValue({ id: 1 });
+      mockCommonService.getConfig.mockResolvedValue([]);
+      mockCommonService.isValidUserContext.mockReturnValue(false);
+      mockCommonService.checkBadWords.mockResolvedValue('Test comment');
+
+      await expect(
+        service.create(
+          {
+            ...mockPayload,
+            author: {
+              name: 'Author Name',
+              email: 'author@test.com',
+            },
+          },
+          undefined,
+        ),
+      ).rejects.toMatchObject({
+        status: 400,
+        message:
+          'Not able to recognise author of a comment. Make sure you\'ve provided "author" property in a payload or authenticated your request properly.',
+      });
+    });
+
+    it('should throw error when approval status is invalid for approval flow', async () => {
+      const strapi = getStrapi();
+      const service = getService(strapi);
+
+      mockCommonService.parseRelationString.mockReturnValue({
+        uid: 'api::test.test',
+        relatedId: '1',
+      });
+      mockFindOne.mockResolvedValue({ id: 1, requireCommentsApproval: false });
+      mockCommonService.getConfig.mockResolvedValue(['api::test.test']);
+      mockCommonService.isValidUserContext.mockReturnValue(true);
+      mockCommonService.checkBadWords.mockResolvedValue('Test comment');
+
+      await expect(
+        service.create(
+          { ...mockPayload, approvalStatus: APPROVAL_STATUS.APPROVED },
+          mockUser,
+        ),
+      ).rejects.toMatchObject({
+        status: 400,
+        message: 'Invalid approval status',
+      });
+    });
+
+    it('should still return created comment when response notification fails', async () => {
+      const strapi = getStrapi();
+      const service = getService(strapi);
+      const mockEntity = { id: 1, content: 'Test comment' };
+      const mockSanitizedEntity = { id: 1, content: 'Clean comment' };
+      const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+      mockCommonService.parseRelationString.mockReturnValue({
+        uid: 'api::test.test',
+        relatedId: '1',
+      });
+      mockFindOne.mockResolvedValue({ id: 1 });
+      mockCommonService.getConfig.mockResolvedValue([]);
+      mockCommonService.isValidUserContext.mockReturnValue(true);
+      mockCommonService.checkBadWords.mockResolvedValue('Test comment');
+      mockCommentRepository.create.mockResolvedValue(mockEntity);
+      mockCommonService.sanitizeCommentEntity.mockReturnValue(mockSanitizedEntity);
+      jest.spyOn(service, 'sendResponseNotification').mockRejectedValue(new Error('Email failed'));
+
+      const result = await service.create(mockPayload, mockUser);
+
+      expect(result).toEqual(mockSanitizedEntity);
+      expect(consoleErrorSpy).toHaveBeenCalled();
+
+      consoleErrorSpy.mockRestore();
+    });
   });
 
   describe('update', () => {
@@ -440,6 +544,50 @@ describe('client.service', () => {
 
       await expect(service.reportAbuse(mockPayload, mockUser)).rejects.toThrow(PluginError);
     });
+
+    it('should throw error when user context is invalid', async () => {
+      const strapi = getStrapi();
+      const service = getService(strapi);
+
+      mockCommonService.isValidUserContext.mockReturnValue(false);
+
+      await expect(service.reportAbuse(mockPayload, mockUser)).rejects.toThrow(PluginError);
+      expect(mockCommonService.findOne).not.toHaveBeenCalled();
+    });
+
+    it('should return report even when abuse report email fails', async () => {
+      const strapi = getStrapi();
+      const service = getService(strapi);
+      const mockComment = { id: 1, content: 'Test comment', isAdminComment: false };
+      const mockReport = { id: 1, reason: REPORT_REASON.BAD_LANGUAGE, content: 'Report content' };
+
+      mockCommonService.isValidUserContext.mockReturnValue(true);
+      mockCommonService.findOne.mockResolvedValue(mockComment);
+      mockReportCommentRepository.create.mockResolvedValue(mockReport);
+      jest.spyOn(service, 'sendAbuseReportEmail').mockRejectedValue(new Error('Email failed'));
+
+      const result = await service.reportAbuse(mockPayload, mockUser);
+
+      expect(result).toEqual({
+        ...mockReport,
+        related: mockComment,
+      });
+    });
+
+    it('should throw error when report cannot be created', async () => {
+      const strapi = getStrapi();
+      const service = getService(strapi);
+      const mockComment = { id: 1, content: 'Test comment', isAdminComment: false };
+
+      mockCommonService.isValidUserContext.mockReturnValue(true);
+      mockCommonService.findOne.mockResolvedValue(mockComment);
+      mockReportCommentRepository.create.mockResolvedValue(null);
+
+      await expect(service.reportAbuse(mockPayload, mockUser)).rejects.toMatchObject({
+        status: 500,
+        message: 'Report cannot be created',
+      });
+    });
   });
 
   describe('markAsRemoved', () => {
@@ -494,6 +642,88 @@ describe('client.service', () => {
       mockCommonService.findOne.mockResolvedValue(null);
 
       await expect(service.markAsRemoved(mockPayload, mockUser)).rejects.toThrow(PluginError);
+    });
+
+    it('should throw error when user context is invalid and authorId is missing', async () => {
+      const strapi = getStrapi();
+      const service = getService(strapi);
+
+      mockCommonService.isValidUserContext.mockReturnValue(false);
+
+      await expect(service.markAsRemoved(mockPayload, undefined as any)).rejects.toThrow(
+        PluginError,
+      );
+      expect(mockCommonService.findOne).not.toHaveBeenCalled();
+    });
+
+    it('should throw error when neither authenticated user id nor authorId is provided', async () => {
+      const strapi = getStrapi();
+      const service = getService(strapi);
+
+      mockCommonService.isValidUserContext.mockReturnValue(true);
+
+      await expect(
+        service.markAsRemoved(
+          { ...mockPayload, authorId: null },
+          { email: 'test@test.com', username: 'test' } as AdminUser,
+        ),
+      ).rejects.toMatchObject({
+        status: 403,
+        message:
+          'You\'re not allowed to take an action on that entity. Make sure that you\'ve provided proper "authorId" or authenticated your request properly.',
+      });
+    });
+
+    it('should mark comment as removed using authorId when no authenticated user is provided', async () => {
+      const strapi = getStrapi();
+      const service = getService(strapi);
+      const mockEntity = {
+        id: 1,
+        documentId: 'doc-1',
+        content: 'Test comment',
+        removed: true,
+        locale: 'pl',
+      };
+      const mockSanitizedEntity = { id: 1, content: '[removed]', removed: true };
+
+      jest.spyOn(service, 'markAsRemovedNested').mockResolvedValue(true);
+
+      mockCommonService.isValidUserContext.mockReturnValue(false);
+      mockCommonService.findOne.mockResolvedValue(mockEntity);
+      mockCommentRepository.findOne.mockResolvedValue(mockEntity);
+      mockCommentRepository.findMany.mockResolvedValue([]);
+      mockCommentRepository.update.mockResolvedValue(mockEntity);
+      mockCommonService.sanitizeCommentEntity.mockReturnValue(mockSanitizedEntity);
+
+      const result = await service.markAsRemoved(
+        { ...mockPayload, authorId: 42 },
+        undefined as any,
+      );
+
+      expect(result).toEqual(mockSanitizedEntity);
+      expect(mockCommonService.findOne).toHaveBeenCalledWith({
+        id: 1,
+        related: 'api::test.test:1',
+        authorId: 42,
+      });
+    });
+  });
+
+  describe('markAsRemovedNested', () => {
+    it('should delegate nested comment removal to common service', async () => {
+      const strapi = getStrapi();
+      const service = getService(strapi);
+
+      mockCommonService.modifiedNestedNestedComments.mockResolvedValue(true);
+
+      const result = await service.markAsRemovedNested(5, true);
+
+      expect(result).toBe(true);
+      expect(mockCommonService.modifiedNestedNestedComments).toHaveBeenCalledWith(
+        5,
+        'removed',
+        true,
+      );
     });
   });
 

--- a/server/src/services/__tests__/client.service.test.ts
+++ b/server/src/services/__tests__/client.service.test.ts
@@ -47,6 +47,8 @@ describe('client.service', () => {
   const mockCommentRepository = {
     create: jest.fn(),
     update: jest.fn(),
+    findOne: jest.fn(),
+    findMany: jest.fn(),
   };
 
   const mockReportCommentRepository = {
@@ -70,9 +72,19 @@ describe('client.service', () => {
     error: jest.fn(),
   };
 
+  const mockReactionsService = {
+    removeForComments: jest.fn().mockResolvedValue(undefined),
+  };
+
   beforeEach(() => {
     jest.clearAllMocks();
-    caster<jest.Mock>(getPluginService).mockReturnValue(mockCommonService);
+    caster<jest.Mock>(getPluginService).mockImplementation((_strapi, name: string) => {
+      if (name === 'reactions') {
+        return mockReactionsService;
+      }
+
+      return mockCommonService;
+    });
     caster<jest.Mock>(getCommentRepository).mockReturnValue(
       mockCommentRepository
     );
@@ -441,13 +453,21 @@ describe('client.service', () => {
     it('should mark comment as removed when all validations pass', async () => {
       const strapi = getStrapi();
       const service = getService(strapi);
-      const mockEntity = { id: 1, content: 'Test comment', removed: true };
+      const mockEntity = {
+        id: 1,
+        documentId: 'doc-1',
+        content: 'Test comment',
+        removed: true,
+        locale: 'en',
+      };
       const mockSanitizedEntity = { id: 1, content: '[removed]', removed: true };
 
       jest.spyOn(service, 'markAsRemovedNested').mockResolvedValue(true);
 
       mockCommonService.isValidUserContext.mockReturnValue(true);
       mockCommonService.findOne.mockResolvedValue(mockEntity);
+      mockCommentRepository.findOne.mockResolvedValue(mockEntity);
+      mockCommentRepository.findMany.mockResolvedValue([]);
       mockCommentRepository.update.mockResolvedValue(mockEntity);
       mockCommonService.sanitizeCommentEntity.mockReturnValue(mockSanitizedEntity);
 
@@ -455,6 +475,7 @@ describe('client.service', () => {
 
       expect(result).toEqual(mockSanitizedEntity);
       expect(service.markAsRemovedNested).toHaveBeenCalledWith(1, true);
+      expect(mockReactionsService.removeForComments).toHaveBeenCalledWith(['doc-1'], 'en');
       expect(mockCommentRepository.update).toHaveBeenCalledWith({
         where: {
           id: 1,

--- a/server/src/services/__tests__/common.service.test.ts
+++ b/server/src/services/__tests__/common.service.test.ts
@@ -27,6 +27,21 @@ jest.mock('no-profanity', () => ({
   replaceProfanities: jest.fn(),
 }));
 
+const mockReactionsService = {
+  getCountsForComments: jest.fn().mockResolvedValue({}),
+  isEnabled: jest.fn().mockResolvedValue(true),
+};
+
+jest.mock('../../utils/getPluginService', () => ({
+  getPluginService: jest.fn((_strapi, name: string) => {
+    if (name === 'reactions') {
+      return mockReactionsService;
+    }
+
+    return {};
+  }),
+}));
+
 describe('common.service', () => {
   const mockCommentRepository = {
     findOne: jest.fn(),
@@ -53,6 +68,9 @@ describe('common.service', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    mockStoreRepository.getLocalConfig.mockReset();
+    mockReactionsService.isEnabled.mockResolvedValue(true);
+    mockReactionsService.getCountsForComments.mockResolvedValue({});
     caster<jest.Mock>(getCommentRepository).mockReturnValue(mockCommentRepository);
     caster<jest.Mock>(getReportCommentRepository).mockReturnValue(mockReportCommentRepository);
     caster<jest.Mock>(getStoreRepository).mockReturnValue(mockStoreRepository);
@@ -111,6 +129,18 @@ describe('common.service', () => {
       const result = await service.getConfig('moderatorRoles', defaultValue, true);
 
       expect(result).toEqual(defaultValue);
+    });
+
+    it('should return default value when prop is missing in store', async () => {
+      const strapi = getStrapi();
+      const service = getService(strapi);
+
+      mockStoreRepository.getConfig.mockResolvedValue({ moderatorRoles: ['admin'] });
+
+      const result = await service.getConfig('reactionsEnabled', false);
+
+      expect(result).toBe(false);
+      expect(mockStoreRepository.getLocalConfig).not.toHaveBeenCalled();
     });
   });
 
@@ -280,6 +310,33 @@ describe('common.service', () => {
       expect(result.data).toHaveLength(2);
       expect(mockCommentRepository.findWithCount).toHaveBeenCalled();
     });
+
+    it('should omit reactions meta when reactions integration is disabled', async () => {
+      const strapi = getStrapi();
+      const service = getService(strapi);
+      const mockComments = [
+        { id: 1, content: 'Comment 1', documentId: 'doc-1' },
+      ];
+
+      mockReactionsService.isEnabled.mockResolvedValue(false);
+      mockCommentRepository.findWithCount.mockResolvedValue({
+        results: mockComments,
+        pagination: { total: 1 },
+      });
+      caster<jest.Mock>(getOrderBy).mockReturnValue(['createdAt', 'desc']);
+      mockStoreRepository.getConfig.mockResolvedValue([]);
+
+      const result = await service.findAllFlat({
+        fields: ['id', 'content'],
+        limit: 10,
+        skip: 0,
+      });
+
+      expect(result.meta).toBeUndefined();
+      expect(result.data[0]).not.toHaveProperty('reactions');
+      expect(mockReactionsService.getCountsForComments).not.toHaveBeenCalled();
+    });
+
     it('should return flat list of comments with populated user properties', async () => {
       const strapi = getStrapi();
       const service = getService(strapi);
@@ -919,7 +976,7 @@ describe('common.service', () => {
             avatar: { populate: true },
           },
         },
-        select: ['id', 'content', 'related'],
+        select: ['id', 'content', 'documentId', 'related'],
         orderBy: { createdAt: 'desc' },
         where: { authorId: 1 },
       });
@@ -965,7 +1022,7 @@ describe('common.service', () => {
         where: { authorUser: { id: 1 } },
         pageSize: 10,
         page: 1,
-        select: ['id', 'content', 'related'],
+        select: ['id', 'content', 'documentId', 'related'],
         orderBy: { createdAt: 'desc' },
         populate: {
           authorUser: {

--- a/server/src/services/__tests__/common.service.test.ts
+++ b/server/src/services/__tests__/common.service.test.ts
@@ -713,6 +713,38 @@ describe('common.service', () => {
 
       expect(typedResult[0].children).toHaveLength(0); // drop blocked threads
     });
+
+    it('should return hierarchy without reactions when reactions integration is disabled', async () => {
+      const strapi = getStrapi();
+      const service = getService(strapi);
+      const mockComments = [
+        { id: 1, content: 'Parent 1', threadOf: null, documentId: 'doc-1', gotThread: true },
+        { id: 2, content: 'Child 1', threadOf: '1', documentId: 'doc-2', gotThread: false },
+      ];
+
+      mockReactionsService.isEnabled.mockResolvedValue(false);
+      mockCommentRepository.findMany.mockResolvedValue(mockComments);
+      caster<jest.Mock>(getOrderBy).mockReturnValue(['createdAt', 'desc']);
+      mockCommentRepository.findWithCount.mockImplementation(async (args) => {
+        const threadOf = args?.where?.threadOf?.$eq ?? null;
+        const filtered = mockComments.filter((c) => c.threadOf === threadOf);
+        return {
+          results: filtered,
+          pagination: { total: filtered.length },
+        };
+      });
+      mockStoreRepository.getConfig.mockResolvedValue([]);
+
+      const result = await service.findAllInHierarchy({
+        fields: ['id', 'content', 'threadOf', 'documentId', 'gotThread'],
+      });
+
+      const typedResult = result as CommentWithChildren[];
+
+      expect(typedResult).toHaveLength(1);
+      expect(typedResult[0]).not.toHaveProperty('reactions');
+      expect(mockReactionsService.getCountsForComments).not.toHaveBeenCalled();
+    });
   });
 
   describe('updateComment', () => {

--- a/server/src/services/__tests__/reactions.service.test.ts
+++ b/server/src/services/__tests__/reactions.service.test.ts
@@ -1,0 +1,128 @@
+import { StrapiContext } from '../../@types';
+import { caster } from '../../test/utils';
+import reactionsService from '../reactions.service';
+
+jest.mock('../../utils/getPluginService', () => ({
+  getPluginService: jest.fn((_strapi, name: string) => {
+    if (name === 'common') {
+      return {
+        getConfig: jest.fn().mockResolvedValue(true),
+      };
+    }
+    return {};
+  }),
+}));
+
+describe('reactions.service', () => {
+  const mockFindMany = jest.fn();
+  const mockDelete = jest.fn();
+
+  const getStrapi = (withReactionsPlugin = true) =>
+    caster<StrapiContext>({
+      strapi: {
+        plugin: jest.fn((name: string) =>
+          withReactionsPlugin && name === 'reactions' ? {} : undefined,
+        ),
+        documents: jest.fn(() => ({
+          findMany: mockFindMany,
+          delete: mockDelete,
+        })),
+      },
+    });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockDelete.mockResolvedValue(true);
+  });
+
+  describe('getCountsForComments', () => {
+    it('should return empty object when reactions plugin is not installed', async () => {
+      const service = reactionsService(getStrapi(false));
+      const result = await service.getCountsForComments(['doc-1']);
+
+      expect(result).toEqual({});
+      expect(mockFindMany).not.toHaveBeenCalled();
+    });
+
+    it('should return empty object when reactions integration is disabled', async () => {
+      const { getPluginService } = jest.requireMock('../../utils/getPluginService');
+      getPluginService.mockImplementationOnce((_strapi: unknown, name: string) => {
+        if (name === 'common') {
+          return {
+            getConfig: jest.fn().mockResolvedValue(false),
+          };
+        }
+        return {};
+      });
+
+      const service = reactionsService(getStrapi());
+      const result = await service.getCountsForComments(['doc-1']);
+
+      expect(result).toEqual({});
+      expect(mockFindMany).not.toHaveBeenCalled();
+    });
+
+    it('should aggregate reaction counts per comment documentId', async () => {
+      mockFindMany.mockResolvedValue([
+        {
+          relatedUid: 'plugin::comments.comment:doc-1',
+          kind: { slug: 'like' },
+        },
+        {
+          relatedUid: 'plugin::comments.comment:doc-1',
+          kind: { slug: 'like' },
+        },
+        {
+          relatedUid: 'plugin::comments.comment:doc-2',
+          kind: { slug: 'love' },
+        },
+      ]);
+
+      const service = reactionsService(getStrapi());
+      const result = await service.getCountsForComments(['doc-1', 'doc-2'], 'en');
+
+      expect(result).toEqual({
+        'doc-1': { like: 2 },
+        'doc-2': { love: 1 },
+      });
+      expect(mockFindMany).toHaveBeenCalledWith({
+        filters: {
+          relatedUid: {
+            $in: [
+              'plugin::comments.comment:doc-1',
+              'plugin::comments.comment:doc-2',
+            ],
+          },
+        },
+        populate: {
+          kind: {
+            fields: ['slug'],
+          },
+        },
+        locale: 'en',
+      });
+    });
+  });
+
+  describe('removeForComments', () => {
+    it('should delete all reactions linked to provided comments', async () => {
+      mockFindMany.mockResolvedValue([
+        { documentId: 'reaction-1' },
+        { documentId: 'reaction-2' },
+      ]);
+
+      const service = reactionsService(getStrapi());
+      await service.removeForComments(['doc-1'], 'en');
+
+      expect(mockDelete).toHaveBeenCalledTimes(2);
+      expect(mockDelete).toHaveBeenCalledWith({
+        documentId: 'reaction-1',
+        locale: 'en',
+      });
+      expect(mockDelete).toHaveBeenCalledWith({
+        documentId: 'reaction-2',
+        locale: 'en',
+      });
+    });
+  });
+});

--- a/server/src/services/__tests__/reactions.service.test.ts
+++ b/server/src/services/__tests__/reactions.service.test.ts
@@ -16,6 +16,7 @@ jest.mock('../../utils/getPluginService', () => ({
 describe('reactions.service', () => {
   const mockFindMany = jest.fn();
   const mockDelete = jest.fn();
+  const mockGetConfig = jest.fn().mockResolvedValue(true);
 
   const getStrapi = (withReactionsPlugin = true) =>
     caster<StrapiContext>({
@@ -30,9 +31,70 @@ describe('reactions.service', () => {
       },
     });
 
+  const mockReactionsDisabled = () => {
+    const { getPluginService } = jest.requireMock('../../utils/getPluginService');
+    getPluginService.mockImplementationOnce((_strapi: unknown, name: string) => {
+      if (name === 'common') {
+        return {
+          getConfig: mockGetConfig.mockResolvedValueOnce(false),
+        };
+      }
+      return {};
+    });
+  };
+
   beforeEach(() => {
     jest.clearAllMocks();
     mockDelete.mockResolvedValue(true);
+    mockGetConfig.mockResolvedValue(true);
+
+    const { getPluginService } = jest.requireMock('../../utils/getPluginService');
+    getPluginService.mockImplementation((_strapi: unknown, name: string) => {
+      if (name === 'common') {
+        return {
+          getConfig: mockGetConfig,
+        };
+      }
+      return {};
+    });
+  });
+
+  describe('isPluginInstalled', () => {
+    it('should return true when reactions plugin is registered', () => {
+      const service = reactionsService(getStrapi());
+
+      expect(service.isPluginInstalled()).toBe(true);
+    });
+
+    it('should return false when reactions plugin is not registered', () => {
+      const service = reactionsService(getStrapi(false));
+
+      expect(service.isPluginInstalled()).toBe(false);
+    });
+  });
+
+  describe('isEnabled', () => {
+    it('should return false when reactions plugin is not installed', async () => {
+      const service = reactionsService(getStrapi(false));
+
+      expect(await service.isEnabled()).toBe(false);
+      expect(mockGetConfig).not.toHaveBeenCalled();
+    });
+
+    it('should return false when reactions integration is disabled in config', async () => {
+      mockGetConfig.mockResolvedValueOnce(false);
+      const service = reactionsService(getStrapi());
+
+      expect(await service.isEnabled()).toBe(false);
+      expect(mockGetConfig).toHaveBeenCalledWith('reactionsEnabled', false);
+    });
+
+    it('should return true when reactions plugin is installed and enabled in config', async () => {
+      const service = reactionsService(getStrapi());
+
+      expect(await service.isEnabled()).toBe(true);
+      expect(mockGetConfig).toHaveBeenCalledWith('reactionsEnabled', false);
+    });
   });
 
   describe('getCountsForComments', () => {
@@ -45,21 +107,54 @@ describe('reactions.service', () => {
     });
 
     it('should return empty object when reactions integration is disabled', async () => {
-      const { getPluginService } = jest.requireMock('../../utils/getPluginService');
-      getPluginService.mockImplementationOnce((_strapi: unknown, name: string) => {
-        if (name === 'common') {
-          return {
-            getConfig: jest.fn().mockResolvedValue(false),
-          };
-        }
-        return {};
-      });
+      mockReactionsDisabled();
 
       const service = reactionsService(getStrapi());
       const result = await service.getCountsForComments(['doc-1']);
 
       expect(result).toEqual({});
       expect(mockFindMany).not.toHaveBeenCalled();
+    });
+
+    it('should return empty object when no valid documentIds are provided', async () => {
+      const service = reactionsService(getStrapi());
+      const result = await service.getCountsForComments([null, undefined, '']);
+
+      expect(result).toEqual({});
+      expect(mockFindMany).not.toHaveBeenCalled();
+    });
+
+    it('should return empty object when findMany returns null', async () => {
+      mockFindMany.mockResolvedValue(null);
+
+      const service = reactionsService(getStrapi());
+      const result = await service.getCountsForComments(['doc-1']);
+
+      expect(result).toEqual({});
+    });
+
+    it('should skip reactions with invalid relatedUid or missing kind slug', async () => {
+      mockFindMany.mockResolvedValue([
+        {
+          relatedUid: 'api::article.article:doc-1',
+          kind: { slug: 'like' },
+        },
+        {
+          relatedUid: 'plugin::comments.comment:doc-2',
+          kind: null,
+        },
+        {
+          relatedUid: 'plugin::comments.comment:doc-3',
+          kind: { slug: 'love' },
+        },
+      ]);
+
+      const service = reactionsService(getStrapi());
+      const result = await service.getCountsForComments(['doc-1', 'doc-2', 'doc-3']);
+
+      expect(result).toEqual({
+        'doc-3': { love: 1 },
+      });
     });
 
     it('should aggregate reaction counts per comment documentId', async () => {
@@ -73,6 +168,10 @@ describe('reactions.service', () => {
           kind: { slug: 'like' },
         },
         {
+          relatedUid: 'plugin::comments.comment:doc-1',
+          kind: { slug: 'love' },
+        },
+        {
           relatedUid: 'plugin::comments.comment:doc-2',
           kind: { slug: 'love' },
         },
@@ -82,7 +181,7 @@ describe('reactions.service', () => {
       const result = await service.getCountsForComments(['doc-1', 'doc-2'], 'en');
 
       expect(result).toEqual({
-        'doc-1': { like: 2 },
+        'doc-1': { like: 2, love: 1 },
         'doc-2': { love: 1 },
       });
       expect(mockFindMany).toHaveBeenCalledWith({
@@ -102,9 +201,43 @@ describe('reactions.service', () => {
         locale: 'en',
       });
     });
+
+    it('should return empty reactions map for each comment when no reactions are found', async () => {
+      mockFindMany.mockResolvedValue([]);
+
+      const service = reactionsService(getStrapi());
+      const result = await service.getCountsForComments(['doc-1', 'doc-2']);
+
+      expect(result).toEqual({});
+    });
   });
 
   describe('removeForComments', () => {
+    it('should not delete reactions when plugin is not installed', async () => {
+      const service = reactionsService(getStrapi(false));
+      await service.removeForComments(['doc-1']);
+
+      expect(mockFindMany).not.toHaveBeenCalled();
+      expect(mockDelete).not.toHaveBeenCalled();
+    });
+
+    it('should not query reactions when no valid documentIds are provided', async () => {
+      const service = reactionsService(getStrapi());
+      await service.removeForComments([null, undefined, '']);
+
+      expect(mockFindMany).not.toHaveBeenCalled();
+      expect(mockDelete).not.toHaveBeenCalled();
+    });
+
+    it('should not delete reactions when findMany returns null', async () => {
+      mockFindMany.mockResolvedValue(null);
+
+      const service = reactionsService(getStrapi());
+      await service.removeForComments(['doc-1']);
+
+      expect(mockDelete).not.toHaveBeenCalled();
+    });
+
     it('should delete all reactions linked to provided comments', async () => {
       mockFindMany.mockResolvedValue([
         { documentId: 'reaction-1' },
@@ -114,6 +247,14 @@ describe('reactions.service', () => {
       const service = reactionsService(getStrapi());
       await service.removeForComments(['doc-1'], 'en');
 
+      expect(mockFindMany).toHaveBeenCalledWith({
+        filters: {
+          relatedUid: {
+            $in: ['plugin::comments.comment:doc-1'],
+          },
+        },
+        locale: 'en',
+      });
       expect(mockDelete).toHaveBeenCalledTimes(2);
       expect(mockDelete).toHaveBeenCalledWith({
         documentId: 'reaction-1',

--- a/server/src/services/admin/admin.service.ts
+++ b/server/src/services/admin/admin.service.ts
@@ -170,7 +170,20 @@ export default ({ strapi }: StrapiContext) => {
       return this.getCommonService().changeBlockedComment(id, forceStatus);
     },
     async deleteComment(id: Id) {
-      return getCommentRepository(strapi).update({ where: { id }, data: { removed: true } });
+      const entity = await getCommentRepository(strapi).findOne({ where: { id } });
+      const removedEntity = await getCommentRepository(strapi).update({
+        where: { id },
+        data: { removed: true },
+      });
+
+      if (entity?.documentId) {
+        await getPluginService(strapi, 'reactions').removeForComments(
+          [entity.documentId],
+          entity.locale,
+        );
+      }
+
+      return removedEntity;
     },
     async blockCommentThread(id: Id, forceStatus?: boolean) {
       return this.getCommonService().changeBlockedCommentThread(id, forceStatus);

--- a/server/src/services/client.service.ts
+++ b/server/src/services/client.service.ts
@@ -10,6 +10,7 @@ import { client } from '../validators/api';
 import { Comment } from '../validators/repositories';
 import { emailService } from './email.service';
 import { resolveUserContextError } from './utils/functions';
+import { collectNestedCommentDocumentIds } from './utils/reactions';
 
 /**
  * Comments Plugin - Client services
@@ -221,6 +222,13 @@ export const clientService = ({ strapi }: StrapiContext) => {
             });
 
           await this.markAsRemovedNested(commentId, true);
+
+          const commentDocumentIds = await collectNestedCommentDocumentIds({ strapi }, commentId);
+          await getPluginService(strapi, 'reactions').removeForComments(
+            commentDocumentIds,
+            removedEntity.locale,
+          );
+
           const doNotPopulateAuthor = await this.getCommonService().getConfig(CONFIG_PARAMS.AUTHOR_BLOCKED_PROPS, []);
 
           return this.getCommonService().sanitizeCommentEntity(removedEntity, doNotPopulateAuthor);

--- a/server/src/services/common.service.ts
+++ b/server/src/services/common.service.ts
@@ -15,9 +15,15 @@ import { client as clientValidator } from '../validators/api';
 import { Comment, CommentRelated, CommentWithRelated } from '../validators/repositories';
 import { Pagination } from '../validators/repositories/utils';
 import { buildAuthorModel, filterOurResolvedReports, getRelatedGroups } from './utils/functions';
+import { getPluginService } from '../utils/getPluginService';
+import { ReactionsMeta } from './reactions.service';
+import {
+  attachReactionsToComments,
+  collectCommentDocumentIds,
+} from './utils/reactions';
 
 const PAGE_SIZE = 10;
-const REQUIRED_FIELDS = ['id'];
+const REQUIRED_FIELDS = ['id', 'documentId'];
 
 type ParsedRelation = {
   uid: UID.ContentType;
@@ -97,9 +103,12 @@ const commonService = ({ strapi }: StrapiContext) => ({
   ): Promise<{
     data: Array<CommentWithRelated | Comment>;
     pagination?: Pagination;
+    meta?: {
+      reactions: ReactionsMeta;
+    };
   }> {
     const omit = baseOmit.filter((field) => !REQUIRED_FIELDS.includes(field));
-    const defaultSelect = (['id', 'related'] as const).filter((field) => !omit.includes(field));
+    const defaultSelect = (['id', 'documentId', 'related'] as const).filter((field) => !omit.includes(field));
 
     const populateClause: clientValidator.FindAllFlatSchema['populate'] = {
       authorUser: {
@@ -187,11 +196,34 @@ const commonService = ({ strapi }: StrapiContext) => ({
       );
     });
 
+    const data = hasRelatedEntitiesToMap
+      ? result.map((_) => this.mergeRelatedEntityTo(_, relatedEntities))
+      : result;
+
+    const reactionsService = getPluginService(strapi, 'reactions');
+    const reactionsEnabled = await reactionsService.isEnabled();
+
+    if (!reactionsEnabled) {
+      return {
+        data,
+        pagination: resultPaginationData,
+      };
+    }
+
+    const reactionsMeta = await reactionsService.getCountsForComments(
+      data.map((entry) => entry.documentId),
+      locale,
+    );
+
     return {
-      data: hasRelatedEntitiesToMap
-        ? result.map((_) => this.mergeRelatedEntityTo(_, relatedEntities))
-        : result,
+      data: attachReactionsToComments(
+        data as Array<CommentWithRelated | Comment>,
+        reactionsMeta,
+      ),
       pagination: resultPaginationData,
+      meta: {
+        reactions: reactionsMeta,
+      },
     };
   },
 
@@ -324,7 +356,18 @@ const commonService = ({ strapi }: StrapiContext) => ({
       )
     );
 
-    return rootEntriesWithChildren;
+    const reactionsService = getPluginService(strapi, 'reactions');
+
+    if (!(await reactionsService.isEnabled())) {
+      return rootEntriesWithChildren;
+    }
+
+    const reactionsMeta = await reactionsService.getCountsForComments(
+      collectCommentDocumentIds(rootEntriesWithChildren),
+      locale,
+    );
+
+    return attachReactionsToComments(rootEntriesWithChildren, reactionsMeta);
   },
 
   // Find single comment
@@ -591,7 +634,7 @@ const commonService = ({ strapi }: StrapiContext) => ({
             }))
         );
       })
-    ).then((result) => result.flat(2));
+    ).then((result) => result.flat(2) as Array<CommentRelated>);
   },
 
   // Merge related entity with comment

--- a/server/src/services/index.ts
+++ b/server/src/services/index.ts
@@ -4,12 +4,14 @@ import adminServices from './admin/admin.service';
 import clientServices from './client.service';
 import commonServices from './common.service';
 import gqlService from './gql.service';
+import reactionsServices from './reactions.service';
 import settingsService from './settings.service';
 
 const pluginServices = {
   admin: adminServices,
   client: clientServices,
   common: commonServices,
+  reactions: reactionsServices,
   settings: settingsService,
   gql: gqlService
 };

--- a/server/src/services/reactions.service.ts
+++ b/server/src/services/reactions.service.ts
@@ -25,7 +25,7 @@ export const reactionsService = ({ strapi }: StrapiContext) => ({
   },
 
   isPluginInstalled() {
-    return Object.keys(strapi.plugins).includes('reactions');
+    return !!strapi.plugin('reactions');
   },
 
   async isEnabled() {

--- a/server/src/services/reactions.service.ts
+++ b/server/src/services/reactions.service.ts
@@ -1,0 +1,139 @@
+import { isArray, isNil } from 'lodash';
+import { StrapiContext } from '../@types';
+import { CONFIG_PARAMS } from '../utils/constants';
+import { getPluginService } from '../utils/getPluginService';
+
+export type ReactionsCount = Record<string, number>;
+export type ReactionsMeta = Record<string, ReactionsCount>;
+
+const REACTION_CONTENT_TYPE_UID = 'plugin::reactions.reaction';
+const COMMENT_RELATED_UID_PREFIX = 'plugin::comments.comment:';
+
+const buildCommentRelatedId = (documentId: string) =>
+  `${COMMENT_RELATED_UID_PREFIX}${documentId}`;
+
+const parseCommentDocumentId = (relatedUid: string) =>
+  relatedUid.startsWith(COMMENT_RELATED_UID_PREFIX)
+    ? relatedUid.slice(COMMENT_RELATED_UID_PREFIX.length)
+    : null;
+
+const emptyCounts = (): ReactionsCount => ({});
+
+export const reactionsService = ({ strapi }: StrapiContext) => ({
+  getCommonService() {
+    return getPluginService(strapi, 'common');
+  },
+
+  isPluginInstalled() {
+    return Object.keys(strapi.plugins).includes('reactions');
+  },
+
+  async isEnabled() {
+    if (!this.isPluginInstalled()) {
+      return false;
+    }
+
+    const enabled = await this.getCommonService().getConfig(
+      CONFIG_PARAMS.REACTIONS_ENABLED,
+      false,
+    );
+
+    return Boolean(enabled);
+  },
+
+  async getCountsForComments(
+    documentIds: Array<string | null | undefined>,
+    locale?: string,
+  ) {
+    if (!(await this.isEnabled())) {
+      return {};
+    }
+
+    const uniqueDocumentIds = [...new Set(documentIds.filter(Boolean))] as string[];
+
+    if (!uniqueDocumentIds.length) {
+      return {};
+    }
+
+    const entities = await strapi.documents(REACTION_CONTENT_TYPE_UID).findMany({
+      filters: {
+        relatedUid: {
+          $in: uniqueDocumentIds.map(buildCommentRelatedId),
+        },
+      },
+      populate: {
+        kind: {
+          fields: ['slug'],
+        },
+      },
+      locale,
+    });
+
+    if (isNil(entities)) {
+      return {};
+    }
+
+    const reactions = !isArray(entities) ? [entities] : entities;
+
+    return reactions.reduce<ReactionsMeta>((acc, entity) => {
+      const commentDocumentId = parseCommentDocumentId(entity.relatedUid);
+
+      if (!commentDocumentId || !entity.kind?.slug) {
+        return acc;
+      }
+
+      const currentCounts = acc[commentDocumentId] || emptyCounts();
+      const slug = entity.kind.slug;
+
+      return {
+        ...acc,
+        [commentDocumentId]: {
+          ...currentCounts,
+          [slug]: (currentCounts[slug] || 0) + 1,
+        },
+      };
+    }, {});
+  },
+
+  async removeForComments(
+    documentIds: Array<string | null | undefined>,
+    locale?: string,
+  ) {
+    if (!(await this.isEnabled())) {
+      return;
+    }
+
+    const uniqueDocumentIds = [...new Set(documentIds.filter(Boolean))] as string[];
+
+    if (!uniqueDocumentIds.length) {
+      return;
+    }
+
+    const entities = await strapi.documents(REACTION_CONTENT_TYPE_UID).findMany({
+      filters: {
+        relatedUid: {
+          $in: uniqueDocumentIds.map(buildCommentRelatedId),
+        },
+      },
+      locale,
+    });
+
+    if (isNil(entities)) {
+      return;
+    }
+
+    const reactions = !isArray(entities) ? [entities] : entities;
+
+    await Promise.all(
+      reactions.map(({ documentId }) =>
+        strapi.documents(REACTION_CONTENT_TYPE_UID).delete({
+          documentId,
+          locale,
+        }),
+      ),
+    );
+  },
+});
+
+export type ReactionsService = ReturnType<typeof reactionsService>;
+export default reactionsService;

--- a/server/src/services/utils/__tests__/isReactionsPluginInstalled.test.ts
+++ b/server/src/services/utils/__tests__/isReactionsPluginInstalled.test.ts
@@ -1,0 +1,21 @@
+import { CoreStrapi } from '../../../@types';
+import { caster } from '../../../test/utils';
+
+describe('isReactionsPluginInstalled', () => {
+  it('returns true when reactions plugin is available', () => {
+    const strapi = caster<CoreStrapi>({
+      plugin: jest.fn().mockReturnValue({}),
+    });
+
+    expect(!!strapi.plugin('reactions')).toBe(true);
+    expect(strapi.plugin).toHaveBeenCalledWith('reactions');
+  });
+
+  it('returns false when reactions plugin is not available', () => {
+    const strapi = caster<CoreStrapi>({
+      plugin: jest.fn().mockReturnValue(undefined),
+    });
+
+    expect(!!strapi.plugin('reactions')).toBe(false);
+  });
+});

--- a/server/src/services/utils/__tests__/reactions.test.ts
+++ b/server/src/services/utils/__tests__/reactions.test.ts
@@ -1,6 +1,27 @@
-import { attachReactionsToComments, collectCommentDocumentIds } from '../reactions';
+import { StrapiContext } from '../../../@types';
+import { getCommentRepository } from '../../../repositories';
+import { caster } from '../../../test/utils';
+import {
+  attachReactionsToComments,
+  collectCommentDocumentIds,
+  collectNestedCommentDocumentIds,
+} from '../reactions';
+
+jest.mock('../../../repositories', () => ({
+  getCommentRepository: jest.fn(),
+}));
 
 describe('reactions utils', () => {
+  const mockCommentRepository = {
+    findOne: jest.fn(),
+    findMany: jest.fn(),
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    caster<jest.Mock>(getCommentRepository).mockReturnValue(mockCommentRepository);
+  });
+
   describe('collectCommentDocumentIds', () => {
     it('should collect documentIds from nested comments', () => {
       const comments = [
@@ -18,6 +39,18 @@ describe('reactions utils', () => {
       ];
 
       expect(collectCommentDocumentIds(comments as any)).toEqual(['doc-1', 'doc-2']);
+    });
+
+    it('should skip comments without documentId', () => {
+      const comments = [
+        {
+          id: 1,
+          documentId: null,
+          children: [{ id: 2, documentId: 'doc-2' }],
+        },
+      ];
+
+      expect(collectCommentDocumentIds(comments as any)).toEqual(['doc-2']);
     });
   });
 
@@ -44,6 +77,54 @@ describe('reactions utils', () => {
       expect((result[0] as { reactions: Record<string, number> }).reactions).toEqual({ like: 2 });
       expect((result[0].children?.[0] as { reactions: Record<string, number> }).reactions).toEqual({
         love: 1,
+      });
+    });
+
+    it('should attach empty reactions when documentId is missing in meta', () => {
+      const comments = [{ id: 1, documentId: 'doc-unknown' }];
+
+      const result = attachReactionsToComments(comments as any, {});
+
+      expect((result[0] as { reactions: Record<string, number> }).reactions).toEqual({});
+    });
+  });
+
+  describe('collectNestedCommentDocumentIds', () => {
+    const getStrapi = () => caster<StrapiContext>({ strapi: {} as StrapiContext['strapi'] });
+
+    it('should return empty array when comment has no documentId', async () => {
+      mockCommentRepository.findOne.mockResolvedValue({ id: 1, documentId: null });
+
+      const result = await collectNestedCommentDocumentIds(getStrapi(), 1);
+
+      expect(result).toEqual([]);
+      expect(mockCommentRepository.findMany).not.toHaveBeenCalled();
+    });
+
+    it('should return empty array when comment is not found', async () => {
+      mockCommentRepository.findOne.mockResolvedValue(null);
+
+      const result = await collectNestedCommentDocumentIds(getStrapi(), 1);
+
+      expect(result).toEqual([]);
+    });
+
+    it('should collect documentIds from nested replies', async () => {
+      mockCommentRepository.findOne
+        .mockResolvedValueOnce({ id: 1, documentId: 'doc-1' })
+        .mockResolvedValueOnce({ id: 2, documentId: 'doc-2' });
+      mockCommentRepository.findMany
+        .mockResolvedValueOnce([{ id: 2 }])
+        .mockResolvedValueOnce([]);
+
+      const result = await collectNestedCommentDocumentIds(getStrapi(), 1);
+
+      expect(result).toEqual(['doc-1', 'doc-2']);
+      expect(mockCommentRepository.findMany).toHaveBeenCalledWith({
+        where: { threadOf: 1 },
+      });
+      expect(mockCommentRepository.findMany).toHaveBeenCalledWith({
+        where: { threadOf: 2 },
       });
     });
   });

--- a/server/src/services/utils/__tests__/reactions.test.ts
+++ b/server/src/services/utils/__tests__/reactions.test.ts
@@ -1,0 +1,50 @@
+import { attachReactionsToComments, collectCommentDocumentIds } from '../reactions';
+
+describe('reactions utils', () => {
+  describe('collectCommentDocumentIds', () => {
+    it('should collect documentIds from nested comments', () => {
+      const comments = [
+        {
+          id: 1,
+          documentId: 'doc-1',
+          children: [
+            {
+              id: 2,
+              documentId: 'doc-2',
+              children: [],
+            },
+          ],
+        },
+      ];
+
+      expect(collectCommentDocumentIds(comments as any)).toEqual(['doc-1', 'doc-2']);
+    });
+  });
+
+  describe('attachReactionsToComments', () => {
+    it('should attach reaction counts to each comment node', () => {
+      const comments = [
+        {
+          id: 1,
+          documentId: 'doc-1',
+          children: [
+            {
+              id: 2,
+              documentId: 'doc-2',
+            },
+          ],
+        },
+      ];
+
+      const result = attachReactionsToComments(comments as any, {
+        'doc-1': { like: 2 },
+        'doc-2': { love: 1 },
+      });
+
+      expect((result[0] as { reactions: Record<string, number> }).reactions).toEqual({ like: 2 });
+      expect((result[0].children?.[0] as { reactions: Record<string, number> }).reactions).toEqual({
+        love: 1,
+      });
+    });
+  });
+});

--- a/server/src/services/utils/reactions.ts
+++ b/server/src/services/utils/reactions.ts
@@ -1,0 +1,56 @@
+import { Id, StrapiContext } from '../../@types';
+import { getCommentRepository } from '../../repositories';
+import { ReactionsCount, ReactionsMeta } from '../reactions.service';
+
+type CommentTreeNode = {
+  documentId?: string | null;
+  children?: Array<CommentTreeNode>;
+};
+
+export const collectCommentDocumentIds = (comments: Array<CommentTreeNode>): Array<string> =>
+  comments.reduce<Array<string>>((acc, comment) => {
+    const documentIds = comment.documentId ? [comment.documentId] : [];
+
+    if (!comment.children?.length) {
+      return [...acc, ...documentIds];
+    }
+
+    return [...acc, ...documentIds, ...collectCommentDocumentIds(comment.children)];
+  }, []);
+
+export const attachReactionsToComments = <T extends CommentTreeNode>(
+  comments: Array<T>,
+  reactionsMeta: ReactionsMeta
+): Array<T & { reactions: ReactionsCount }> =>
+  comments.map((comment) => ({
+    ...comment,
+    reactions: reactionsMeta[comment.documentId] || {},
+    ...(comment.children?.length
+      ? {
+          children: attachReactionsToComments(comment.children, reactionsMeta),
+        }
+      : {}),
+  }));
+
+export const collectNestedCommentDocumentIds = async (
+  { strapi }: StrapiContext,
+  commentId: Id
+): Promise<Array<string>> => {
+  const entity = await getCommentRepository(strapi).findOne({
+    where: { id: commentId },
+  });
+
+  if (!entity?.documentId) {
+    return [];
+  }
+
+  const children = await getCommentRepository(strapi).findMany({
+    where: { threadOf: commentId },
+  });
+
+  const nestedDocumentIds = await Promise.all(
+    children.map((child) => collectNestedCommentDocumentIds({ strapi }, child.id))
+  );
+
+  return [entity.documentId, ...nestedDocumentIds.flat()];
+};

--- a/server/src/utils/constants.ts
+++ b/server/src/utils/constants.ts
@@ -7,6 +7,7 @@ export const CONFIG_PARAMS = {
   MODERATOR_ROLES: 'moderatorRoles',
   BAD_WORDS: 'badWords',
   AUTHOR_BLOCKED_PROPS: 'blockedAuthorProps',
+  REACTIONS_ENABLED: 'reactionsEnabled',
 } as const;
 
 export const APPROVAL_STATUS = {


### PR DESCRIPTION
## Ticket

https://github.com/VirtusLab/strapi-plugin-comments/issues/36

## Summary

PR adds ready-made integration with the Reactions plugin through a single setting in the admin panel. This functionality enriches responses from endpoints with metadata for saved reactions.

## Test Plan

Install the Reactions plugin and enable the integration on the settings page. Then, add reactions to your content and check the Comments endpoint - it should include information about these reactions, as well as metadata and a summary.
