### PR TITLE
feat: dependency injection and comments threads

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,4 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
-yarn test:unit
+npm run test:unit

--- a/server/src/controllers/__tests__/admin.controller.test.ts
+++ b/server/src/controllers/__tests__/admin.controller.test.ts
@@ -8,10 +8,6 @@ jest.mock('../../utils/getPluginService', () => ({
   getPluginService: jest.fn(),
 }));
 
-const mockCommentRepository = {};
-jest.mock('../../repositories', () => ({
-  getCommentRepository: jest.fn(() => mockCommentRepository),
-}));
 
 jest.mock('../../validators/api', () => ({
   admin: {
@@ -66,7 +62,7 @@ describe('Admin controller', () => {
       const result = await getController(getStrapi()).findAll(ctx);
 
       expect(result).toEqual(expectedResult);
-      expect(mockAdminService.findAll).toHaveBeenCalledWith(validatedData, mockCommentRepository);
+      expect(mockAdminService.findAll).toHaveBeenCalledWith(validatedData);
     });
 
     it('should throw error when validation fails', async () => {
@@ -91,7 +87,7 @@ describe('Admin controller', () => {
       const result = await getController(getStrapi()).findReports(ctx);
 
       expect(result).toEqual(expectedResult);
-      expect(mockAdminService.findReports).toHaveBeenCalledWith(validatedData, mockCommentRepository);
+      expect(mockAdminService.findReports).toHaveBeenCalledWith(validatedData);
     });
 
     it('should throw error when validation fails', async () => {
@@ -125,7 +121,7 @@ describe('Admin controller', () => {
       const result = await getController(getStrapi()).findOne(ctx);
 
       expect(result).toEqual(expectedResult);
-      expect(mockAdminService.findOneAndThread).toHaveBeenCalledWith(validatedData, mockCommentRepository);
+      expect(mockAdminService.findOneAndThread).toHaveBeenCalledWith(validatedData);
     });
 
     it('should throw error when validation fails', async () => {
@@ -239,7 +235,7 @@ describe('Admin controller', () => {
       const result = await getController(getStrapi()).postCommentThread(ctx);
 
       expect(result).toEqual(expectedResult);
-      expect(mockAdminService.postCommentThread).toHaveBeenCalledWith(validatedData, mockCommentRepository);
+      expect(mockAdminService.postCommentThread).toHaveBeenCalledWith(validatedData);
     });
 
     it('should throw error when validation fails', async () => {
@@ -292,7 +288,7 @@ describe('Admin controller', () => {
       const result = await getController(getStrapi()).deleteComment(ctx);
 
       expect(result).toEqual(expectedResult);
-      expect(mockAdminService.deleteComment).toHaveBeenCalledWith('1', mockCommentRepository);
+      expect(mockAdminService.deleteComment).toHaveBeenCalledWith('1');
     });
 
     it('should throw error when validation fails', async () => {
@@ -392,7 +388,7 @@ describe('Admin controller', () => {
       const result = await getController(getStrapi()).resolveAllAbuseReportsForThread(ctx);
 
       expect(result).toEqual(expectedResult);
-      expect(mockAdminService.resolveAllAbuseReportsForThread).toHaveBeenCalledWith('1', mockCommentRepository);
+      expect(mockAdminService.resolveAllAbuseReportsForThread).toHaveBeenCalledWith('1');
     });
 
     it('should throw error when validation fails', async () => {
@@ -447,7 +443,7 @@ describe('Admin controller', () => {
       const result = await getController(getStrapi()).updateComment(ctx);
 
       expect(result).toEqual(expectedResult);
-      expect(mockAdminService.updateComment).toHaveBeenCalledWith(validatedData, mockCommentRepository);
+      expect(mockAdminService.updateComment).toHaveBeenCalledWith(validatedData);
     });
 
     it('should throw error when validation fails', async () => {
@@ -475,7 +471,7 @@ describe('Admin controller', () => {
       const result = await getController(getStrapi()).approveComment(ctx);
 
       expect(result).toEqual(expectedResult);
-      expect(mockAdminService.approveComment).toHaveBeenCalledWith('1', mockCommentRepository);
+      expect(mockAdminService.approveComment).toHaveBeenCalledWith('1');
     });
 
     it('should throw error when validation fails', async () => {
@@ -500,7 +496,7 @@ describe('Admin controller', () => {
       const result = await getController(getStrapi()).rejectComment(ctx);
 
       expect(result).toEqual(expectedResult);
-      expect(mockAdminService.rejectComment).toHaveBeenCalledWith('1', mockCommentRepository);
+      expect(mockAdminService.rejectComment).toHaveBeenCalledWith('1');
     });
 
     it('should throw error when validation fails', async () => {

--- a/server/src/controllers/__tests__/admin.controller.test.ts
+++ b/server/src/controllers/__tests__/admin.controller.test.ts
@@ -8,6 +8,11 @@ jest.mock('../../utils/getPluginService', () => ({
   getPluginService: jest.fn(),
 }));
 
+const mockCommentRepository = {};
+jest.mock('../../repositories', () => ({
+  getCommentRepository: jest.fn(() => mockCommentRepository),
+}));
+
 jest.mock('../../validators/api', () => ({
   admin: {
     getCommentFindAllValidator: jest.fn(),
@@ -61,7 +66,7 @@ describe('Admin controller', () => {
       const result = await getController(getStrapi()).findAll(ctx);
 
       expect(result).toEqual(expectedResult);
-      expect(mockAdminService.findAll).toHaveBeenCalledWith(validatedData);
+      expect(mockAdminService.findAll).toHaveBeenCalledWith(validatedData, mockCommentRepository);
     });
 
     it('should throw error when validation fails', async () => {
@@ -86,7 +91,7 @@ describe('Admin controller', () => {
       const result = await getController(getStrapi()).findReports(ctx);
 
       expect(result).toEqual(expectedResult);
-      expect(mockAdminService.findReports).toHaveBeenCalledWith(validatedData);
+      expect(mockAdminService.findReports).toHaveBeenCalledWith(validatedData, mockCommentRepository);
     });
 
     it('should throw error when validation fails', async () => {
@@ -120,7 +125,7 @@ describe('Admin controller', () => {
       const result = await getController(getStrapi()).findOne(ctx);
 
       expect(result).toEqual(expectedResult);
-      expect(mockAdminService.findOneAndThread).toHaveBeenCalledWith(validatedData);
+      expect(mockAdminService.findOneAndThread).toHaveBeenCalledWith(validatedData, mockCommentRepository);
     });
 
     it('should throw error when validation fails', async () => {
@@ -234,7 +239,7 @@ describe('Admin controller', () => {
       const result = await getController(getStrapi()).postComment(ctx);
 
       expect(result).toEqual(expectedResult);
-      expect(mockAdminService.postComment).toHaveBeenCalledWith(validatedData);
+      expect(mockAdminService.postComment).toHaveBeenCalledWith(validatedData, mockCommentRepository);
     });
 
     it('should throw error when validation fails', async () => {
@@ -287,7 +292,7 @@ describe('Admin controller', () => {
       const result = await getController(getStrapi()).deleteComment(ctx);
 
       expect(result).toEqual(expectedResult);
-      expect(mockAdminService.deleteComment).toHaveBeenCalledWith('1');
+      expect(mockAdminService.deleteComment).toHaveBeenCalledWith('1', mockCommentRepository);
     });
 
     it('should throw error when validation fails', async () => {
@@ -387,7 +392,7 @@ describe('Admin controller', () => {
       const result = await getController(getStrapi()).resolveAllAbuseReportsForThread(ctx);
 
       expect(result).toEqual(expectedResult);
-      expect(mockAdminService.resolveAllAbuseReportsForThread).toHaveBeenCalledWith('1');
+      expect(mockAdminService.resolveAllAbuseReportsForThread).toHaveBeenCalledWith('1', mockCommentRepository);
     });
 
     it('should throw error when validation fails', async () => {
@@ -442,7 +447,7 @@ describe('Admin controller', () => {
       const result = await getController(getStrapi()).updateComment(ctx);
 
       expect(result).toEqual(expectedResult);
-      expect(mockAdminService.updateComment).toHaveBeenCalledWith(validatedData);
+      expect(mockAdminService.updateComment).toHaveBeenCalledWith(validatedData, mockCommentRepository);
     });
 
     it('should throw error when validation fails', async () => {
@@ -470,7 +475,7 @@ describe('Admin controller', () => {
       const result = await getController(getStrapi()).approveComment(ctx);
 
       expect(result).toEqual(expectedResult);
-      expect(mockAdminService.approveComment).toHaveBeenCalledWith('1');
+      expect(mockAdminService.approveComment).toHaveBeenCalledWith('1', mockCommentRepository);
     });
 
     it('should throw error when validation fails', async () => {
@@ -495,7 +500,7 @@ describe('Admin controller', () => {
       const result = await getController(getStrapi()).rejectComment(ctx);
 
       expect(result).toEqual(expectedResult);
-      expect(mockAdminService.rejectComment).toHaveBeenCalledWith('1');
+      expect(mockAdminService.rejectComment).toHaveBeenCalledWith('1', mockCommentRepository);
     });
 
     it('should throw error when validation fails', async () => {

--- a/server/src/controllers/__tests__/admin.controller.test.ts
+++ b/server/src/controllers/__tests__/admin.controller.test.ts
@@ -40,7 +40,7 @@ describe('Admin controller', () => {
     resolveAllAbuseReportsForComment: jest.fn(),
     resolveAllAbuseReportsForThread: jest.fn(),
     resolveMultipleAbuseReports: jest.fn(),
-    postComment: jest.fn(),
+    postCommentThread: jest.fn(),
     updateComment: jest.fn(),
     approveComment: jest.fn(),
     rejectComment: jest.fn(),
@@ -224,8 +224,8 @@ describe('Admin controller', () => {
     });
   });
 
-  describe('postComment', () => {
-    it('should post comment when validation passes', async () => {
+  describe('postCommentThread', () => {
+    it('should post comment to thread when validation passes', async () => {
       const ctx = {
         params: { id: '1' },
         request: { body: { content: 'Test content', author: 'Test author' } }
@@ -234,12 +234,12 @@ describe('Admin controller', () => {
       const expectedResult = { id: 1, content: 'Test content' };
 
       caster<jest.Mock>(adminValidator.getCommentPostValidator).mockReturnValue({ right: validatedData });
-      mockAdminService.postComment.mockResolvedValue(expectedResult);
+      mockAdminService.postCommentThread.mockResolvedValue(expectedResult);
 
-      const result = await getController(getStrapi()).postComment(ctx);
+      const result = await getController(getStrapi()).postCommentThread(ctx);
 
       expect(result).toEqual(expectedResult);
-      expect(mockAdminService.postComment).toHaveBeenCalledWith(validatedData, mockCommentRepository);
+      expect(mockAdminService.postCommentThread).toHaveBeenCalledWith(validatedData, mockCommentRepository);
     });
 
     it('should throw error when validation fails', async () => {
@@ -251,7 +251,7 @@ describe('Admin controller', () => {
 
       caster<jest.Mock>(adminValidator.getCommentPostValidator).mockReturnValue({ left: error });
 
-      await expect(getController(getStrapi()).postComment(ctx)).rejects.toThrow();
+      await expect(getController(getStrapi()).postCommentThread(ctx)).rejects.toThrow();
     });
   });
 

--- a/server/src/controllers/admin.controller.ts
+++ b/server/src/controllers/admin.controller.ts
@@ -123,7 +123,7 @@ const controllers = ({ strapi }: StrapiContext) => ({
     throw throwError(ctx, unwrapEither(either));
   },
 
-  async postComment(ctx: RequestContext<Omit<adminValidator.CommentPostValidatorSchema, 'id'>, Pick<adminValidator.CommentPostValidatorSchema, 'id'>>) {
+  async postCommentThread(ctx: RequestContext<Omit<adminValidator.CommentPostValidatorSchema, 'id'>, Pick<adminValidator.CommentPostValidatorSchema, 'id'>>) {
     const either = adminValidator.getCommentPostValidator({
       id: ctx.params.id,
       content: ctx.request.body.content,
@@ -131,7 +131,7 @@ const controllers = ({ strapi }: StrapiContext) => ({
     });
     if (isRight(either)) {
       const commentRepository = getCommentRepository(strapi);
-      return this.getService('admin').postComment(unwrapEither(either), commentRepository);
+      return this.getService('admin').postCommentThread(unwrapEither(either), commentRepository);
     }
     throw throwError(ctx, unwrapEither(either));
   },

--- a/server/src/controllers/admin.controller.ts
+++ b/server/src/controllers/admin.controller.ts
@@ -1,4 +1,5 @@
 import { Id, RequestContext, StrapiContext } from '../@types';
+import { getCommentRepository } from '../repositories';
 import { PluginServices } from '../services';
 import { isRight, unwrapEither } from '../utils/Either';
 import { getPluginService } from '../utils/getPluginService';
@@ -13,7 +14,8 @@ const controllers = ({ strapi }: StrapiContext) => ({
   async findAll(ctx: RequestContext) {
     const either = adminValidator.getCommentFindAllValidator(ctx.query);
     if (isRight(either)) {
-      return this.getService('admin').findAll(unwrapEither(either));
+      const commentRepository = getCommentRepository(strapi);
+      return this.getService('admin').findAll(unwrapEither(either), commentRepository);
     }
     throw throwError(ctx, unwrapEither(either));
   },
@@ -21,7 +23,8 @@ const controllers = ({ strapi }: StrapiContext) => ({
   async findReports(ctx: RequestContext) {
     const either = adminValidator.getReportFindReportsValidator(ctx.query);
     if (isRight(either)) {
-      return this.getService('admin').findReports(unwrapEither(either));
+      const commentRepository = getCommentRepository(strapi);
+      return this.getService('admin').findReports(unwrapEither(either), commentRepository);
     }
     throw throwError(ctx, unwrapEither(either));
   },
@@ -29,7 +32,8 @@ const controllers = ({ strapi }: StrapiContext) => ({
   async findOne(ctx: RequestContextWithId) {
     const either = adminValidator.getCommentFindOneValidator(ctx.params.id, ctx.query);
     if (isRight(either)) {
-      return this.getService('admin').findOneAndThread(unwrapEither(either));
+      const commentRepository = getCommentRepository(strapi);
+      return this.getService('admin').findOneAndThread(unwrapEither(either), commentRepository);
     }
     throw throwError(ctx, unwrapEither(either));
   },
@@ -53,7 +57,8 @@ const controllers = ({ strapi }: StrapiContext) => ({
   async deleteComment(ctx: RequestContextWithId) {
     const either = adminValidator.getIdValidator(ctx.params);
     if (isRight(either)) {
-      return this.getService('admin').deleteComment(unwrapEither(either).id);
+      const commentRepository = getCommentRepository(strapi);
+      return this.getService('admin').deleteComment(unwrapEither(either).id, commentRepository);
     }
     throw throwError(ctx, unwrapEither(either));
   },
@@ -104,7 +109,8 @@ const controllers = ({ strapi }: StrapiContext) => ({
   async resolveAllAbuseReportsForThread(ctx: RequestContextWithId) {
     const either = adminValidator.getIdValidator(ctx.params);
     if (isRight(either)) {
-      return this.getService('admin').resolveAllAbuseReportsForThread(unwrapEither(either).id);
+      const commentRepository = getCommentRepository(strapi);
+      return this.getService('admin').resolveAllAbuseReportsForThread(unwrapEither(either).id, commentRepository);
     }
     throw throwError(ctx, unwrapEither(either));
   },
@@ -124,7 +130,8 @@ const controllers = ({ strapi }: StrapiContext) => ({
       author: ctx.request.body.author,
     });
     if (isRight(either)) {
-      return this.getService('admin').postComment(unwrapEither(either));
+      const commentRepository = getCommentRepository(strapi);
+      return this.getService('admin').postComment(unwrapEither(either), commentRepository);
     }
     throw throwError(ctx, unwrapEither(either));
   },
@@ -135,7 +142,8 @@ const controllers = ({ strapi }: StrapiContext) => ({
       content: ctx.request.body.content,
     });
     if (isRight(either)) {
-      return this.getService('admin').updateComment(unwrapEither(either));
+      const commentRepository = getCommentRepository(strapi);
+      return this.getService('admin').updateComment(unwrapEither(either), commentRepository);
     }
     throw throwError(ctx, unwrapEither(either));
   },
@@ -143,7 +151,8 @@ const controllers = ({ strapi }: StrapiContext) => ({
   async approveComment(ctx: RequestContext<object, adminValidator.IdValidatorSchema>) {
     const either = adminValidator.getIdValidator(ctx.params);
     if (isRight(either)) {
-      return this.getService('admin').approveComment(unwrapEither(either).id);
+      const commentRepository = getCommentRepository(strapi);
+      return this.getService('admin').approveComment(unwrapEither(either).id, commentRepository);
     }
     throw throwError(ctx, unwrapEither(either));
   },
@@ -151,7 +160,8 @@ const controllers = ({ strapi }: StrapiContext) => ({
   async rejectComment(ctx: RequestContext<object, adminValidator.IdValidatorSchema>) {
     const either = adminValidator.getIdValidator(ctx.params);
     if (isRight(either)) {
-      return this.getService('admin').rejectComment(unwrapEither(either).id);
+      const commentRepository = getCommentRepository(strapi);
+      return this.getService('admin').rejectComment(unwrapEither(either).id, commentRepository);
     }
     throw throwError(ctx, unwrapEither(either));
   },

--- a/server/src/controllers/admin.controller.ts
+++ b/server/src/controllers/admin.controller.ts
@@ -1,5 +1,4 @@
 import { Id, RequestContext, StrapiContext } from '../@types';
-import { getCommentRepository } from '../repositories';
 import { PluginServices } from '../services';
 import { isRight, unwrapEither } from '../utils/Either';
 import { getPluginService } from '../utils/getPluginService';
@@ -14,8 +13,7 @@ const controllers = ({ strapi }: StrapiContext) => ({
   async findAll(ctx: RequestContext) {
     const either = adminValidator.getCommentFindAllValidator(ctx.query);
     if (isRight(either)) {
-      const commentRepository = getCommentRepository(strapi);
-      return this.getService('admin').findAll(unwrapEither(either), commentRepository);
+      return this.getService('admin').findAll(unwrapEither(either));
     }
     throw throwError(ctx, unwrapEither(either));
   },
@@ -23,8 +21,7 @@ const controllers = ({ strapi }: StrapiContext) => ({
   async findReports(ctx: RequestContext) {
     const either = adminValidator.getReportFindReportsValidator(ctx.query);
     if (isRight(either)) {
-      const commentRepository = getCommentRepository(strapi);
-      return this.getService('admin').findReports(unwrapEither(either), commentRepository);
+      return this.getService('admin').findReports(unwrapEither(either));
     }
     throw throwError(ctx, unwrapEither(either));
   },
@@ -32,8 +29,7 @@ const controllers = ({ strapi }: StrapiContext) => ({
   async findOne(ctx: RequestContextWithId) {
     const either = adminValidator.getCommentFindOneValidator(ctx.params.id, ctx.query);
     if (isRight(either)) {
-      const commentRepository = getCommentRepository(strapi);
-      return this.getService('admin').findOneAndThread(unwrapEither(either), commentRepository);
+      return this.getService('admin').findOneAndThread(unwrapEither(either));
     }
     throw throwError(ctx, unwrapEither(either));
   },
@@ -57,8 +53,7 @@ const controllers = ({ strapi }: StrapiContext) => ({
   async deleteComment(ctx: RequestContextWithId) {
     const either = adminValidator.getIdValidator(ctx.params);
     if (isRight(either)) {
-      const commentRepository = getCommentRepository(strapi);
-      return this.getService('admin').deleteComment(unwrapEither(either).id, commentRepository);
+      return this.getService('admin').deleteComment(unwrapEither(either).id);
     }
     throw throwError(ctx, unwrapEither(either));
   },
@@ -109,8 +104,7 @@ const controllers = ({ strapi }: StrapiContext) => ({
   async resolveAllAbuseReportsForThread(ctx: RequestContextWithId) {
     const either = adminValidator.getIdValidator(ctx.params);
     if (isRight(either)) {
-      const commentRepository = getCommentRepository(strapi);
-      return this.getService('admin').resolveAllAbuseReportsForThread(unwrapEither(either).id, commentRepository);
+      return this.getService('admin').resolveAllAbuseReportsForThread(unwrapEither(either).id);
     }
     throw throwError(ctx, unwrapEither(either));
   },
@@ -130,8 +124,7 @@ const controllers = ({ strapi }: StrapiContext) => ({
       author: ctx.request.body.author,
     });
     if (isRight(either)) {
-      const commentRepository = getCommentRepository(strapi);
-      return this.getService('admin').postCommentThread(unwrapEither(either), commentRepository);
+      return this.getService('admin').postCommentThread(unwrapEither(either));
     }
     throw throwError(ctx, unwrapEither(either));
   },
@@ -142,8 +135,7 @@ const controllers = ({ strapi }: StrapiContext) => ({
       content: ctx.request.body.content,
     });
     if (isRight(either)) {
-      const commentRepository = getCommentRepository(strapi);
-      return this.getService('admin').updateComment(unwrapEither(either), commentRepository);
+      return this.getService('admin').updateComment(unwrapEither(either));
     }
     throw throwError(ctx, unwrapEither(either));
   },
@@ -151,8 +143,7 @@ const controllers = ({ strapi }: StrapiContext) => ({
   async approveComment(ctx: RequestContext<object, adminValidator.IdValidatorSchema>) {
     const either = adminValidator.getIdValidator(ctx.params);
     if (isRight(either)) {
-      const commentRepository = getCommentRepository(strapi);
-      return this.getService('admin').approveComment(unwrapEither(either).id, commentRepository);
+      return this.getService('admin').approveComment(unwrapEither(either).id);
     }
     throw throwError(ctx, unwrapEither(either));
   },
@@ -160,8 +151,7 @@ const controllers = ({ strapi }: StrapiContext) => ({
   async rejectComment(ctx: RequestContext<object, adminValidator.IdValidatorSchema>) {
     const either = adminValidator.getIdValidator(ctx.params);
     if (isRight(either)) {
-      const commentRepository = getCommentRepository(strapi);
-      return this.getService('admin').rejectComment(unwrapEither(either).id, commentRepository);
+      return this.getService('admin').rejectComment(unwrapEither(either).id);
     }
     throw throwError(ctx, unwrapEither(either));
   },

--- a/server/src/routes/admin.routes.ts
+++ b/server/src/routes/admin.routes.ts
@@ -132,7 +132,7 @@ const adminRoutes: StrapiRoute<'admin'>[] = [
   {
     method: 'POST',
     path: '/moderate/thread/:id/postComment',
-    handler: 'admin.postComment',
+    handler: 'admin.postCommentThread',
     config: {
       policies: [],
     },

--- a/server/src/services/__tests__/admin.service.test.ts
+++ b/server/src/services/__tests__/admin.service.test.ts
@@ -780,6 +780,43 @@ describe('admin.service', () => {
     });
   });
 
+  describe('blockNestedThreads', () => {
+    it('should delegate to common service', async () => {
+      const strapi = getStrapi();
+      const service = getService(strapi);
+
+      mockCommonService.modifiedNestedNestedComments.mockResolvedValue(true);
+
+      const result = await service.blockNestedThreads(1, true, mockCommentRepository);
+
+      expect(result).toBe(true);
+      expect(mockCommonService.modifiedNestedNestedComments).toHaveBeenCalledWith(
+        1,
+        'blockedThread',
+        true,
+        undefined,
+        mockCommentRepository,
+      );
+    });
+
+    it('should pass blockedThread status to common service', async () => {
+      const strapi = getStrapi();
+      const service = getService(strapi);
+
+      mockCommonService.modifiedNestedNestedComments.mockResolvedValue(true);
+
+      await service.blockNestedThreads(1, false, mockCommentRepository);
+
+      expect(mockCommonService.modifiedNestedNestedComments).toHaveBeenCalledWith(
+        1,
+        'blockedThread',
+        false,
+        undefined,
+        mockCommentRepository,
+      );
+    });
+  });
+
   describe('approveComment', () => {
     it('should delegate to common service', async () => {
       const strapi = getStrapi();

--- a/server/src/services/__tests__/admin.service.test.ts
+++ b/server/src/services/__tests__/admin.service.test.ts
@@ -791,7 +791,7 @@ describe('admin.service', () => {
       const result = await service.approveComment(1, mockCommentRepository);
 
       expect(result).toEqual(mockResult);
-      expect(mockCommonService.approveComment).toHaveBeenCalledWith(1);
+      expect(mockCommonService.approveComment).toHaveBeenCalledWith(1, mockCommentRepository);
     });
   });
 
@@ -959,7 +959,7 @@ describe('admin.service', () => {
       const result = await service.rejectComment(1, mockCommentRepository);
 
       expect(result).toEqual(mockResult);
-      expect(mockCommonService.rejectComment).toHaveBeenCalledWith(1);
+      expect(mockCommonService.rejectComment).toHaveBeenCalledWith(1, mockCommentRepository);
     });
   });
 
@@ -1046,7 +1046,7 @@ describe('admin.service', () => {
       const result = await service.resolveAllAbuseReportsForThread(1, mockCommentRepository);
 
       expect(result).toEqual(expected);
-      expect(mockCommonService.resolveAllAbuseReportsForThread).toHaveBeenCalledWith(1);
+      expect(mockCommonService.resolveAllAbuseReportsForThread).toHaveBeenCalledWith(1, mockCommentRepository);
     });
   });
 

--- a/server/src/services/__tests__/admin.service.test.ts
+++ b/server/src/services/__tests__/admin.service.test.ts
@@ -814,7 +814,41 @@ describe('admin.service', () => {
   });
 
   describe('postComment', () => {
-    it('should post admin comment', async () => {
+    it('should post admin top-level comment', async () => {
+      const strapi = getStrapi();
+      const service = getService(strapi);
+      const mockAuthor = { id: 1, email: 'admin@test.com' };
+      const relation = 'api::article.article:1';
+
+      mockCommentRepository.create.mockResolvedValue({
+        id: 1,
+        content: 'Admin comment',
+        threadOf: null,
+        related: relation,
+        isAdminComment: true,
+      });
+
+      const result = await service.postComment({
+        id: relation,
+        content: 'Admin comment',
+        author: mockAuthor,
+      }, mockCommentRepository);
+
+      expect(result.isAdminComment).toBe(true);
+      expect(result.threadOf).toBeNull();
+      expect(mockCommentRepository.create).toHaveBeenCalledWith({
+        data: expect.objectContaining({
+          content: 'Admin comment',
+          threadOf: null,
+          related: relation,
+          isAdminComment: true,
+        }),
+      });
+    });
+  });
+
+  describe('postCommentThread', () => {
+    it('should post admin reply to thread', async () => {
       const strapi = getStrapi();
       const service = getService(strapi);
       const mockComment = { id: 1, content: 'Test comment', related: 'api::test.test:1' };
@@ -828,7 +862,7 @@ describe('admin.service', () => {
         isAdminComment: true,
       });
 
-      const result = await service.postComment({
+      const result = await service.postCommentThread({
         id: 1,
         content: 'Admin reply',
         author: mockAuthor,
@@ -836,6 +870,7 @@ describe('admin.service', () => {
 
       expect(result.isAdminComment).toBe(true);
       expect(result.threadOf).toBe(1);
+      expect(mockCommentRepository.findOne).toHaveBeenCalledWith({ where: { id: 1 } });
       expect(mockCommentRepository.create).toHaveBeenCalled();
     });
 
@@ -846,7 +881,7 @@ describe('admin.service', () => {
       mockCommentRepository.findOne.mockResolvedValue(null);
 
       await expect(
-        service.postComment({
+        service.postCommentThread({
           id: 1,
           content: 'Admin reply',
           author: { id: 1, email: 'admin@test.com' },

--- a/server/src/services/__tests__/admin.service.test.ts
+++ b/server/src/services/__tests__/admin.service.test.ts
@@ -7,8 +7,8 @@ import { getPluginService } from '../../utils/getPluginService';
 import adminService from '../admin/admin.service';
 
 jest.mock('../../repositories', () => ({
-  getCommentRepository: jest.fn(),
   getReportCommentRepository: jest.fn(),
+  getCommentRepository: jest.fn(),
 }));
 
 jest.mock('../../repositories/utils', () => ({
@@ -51,6 +51,7 @@ describe('admin.service', () => {
     findWithCount: jest.fn(),
     create: jest.fn(),
     delete: jest.fn(),
+    deleteMany: jest.fn(),
   };
 
   const mockReportCommentRepository = {
@@ -117,7 +118,7 @@ describe('admin.service', () => {
         pageSize: 10,
         orderBy: 'created:DESC',
         _q: 'test search',
-      });
+      }, mockCommentRepository);
 
       expect(result.result).toHaveLength(2);
       expect(result.pagination).toBeDefined();
@@ -161,7 +162,7 @@ describe('admin.service', () => {
       await service.findAll({
         page: 1,
         pageSize: 10,
-      });
+      }, mockCommentRepository);
 
       expect(mockCommentRepository.findWithCount).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -191,7 +192,7 @@ describe('admin.service', () => {
         page: 1,
         pageSize: 10,
         orderBy: 'custoOrder:DESC',
-      });
+      }, mockCommentRepository);
 
       expect(result.result).toHaveLength(2);
       expect(result.pagination).toBeDefined();
@@ -231,7 +232,7 @@ describe('admin.service', () => {
       await service.findReports({
         page: 1,
         pageSize: 10,
-      });
+      }, mockCommentRepository);
 
       expect(mockReportCommentRepository.findPage).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -258,7 +259,7 @@ describe('admin.service', () => {
         page: 1,
         pageSize: 10,
         _q: 'search term',
-      });
+      }, mockCommentRepository);
 
       expect(result.result).toHaveLength(1);
       expect(mockReportCommentRepository.findPage).toHaveBeenCalledWith(
@@ -291,7 +292,7 @@ describe('admin.service', () => {
         page: 1,
         pageSize: 10,
         orderBy: 'resolved:ASC',
-      });
+      }, mockCommentRepository);
 
       expect(result.result).toHaveLength(2);
       expect(mockReportCommentRepository.findPage).toHaveBeenCalledWith({
@@ -332,7 +333,7 @@ describe('admin.service', () => {
       const result = await service.findReports({
         page: 1,
         pageSize: 10,
-      });
+      }, mockCommentRepository);
 
       expect(result.result).toHaveLength(1);
       expect(mockCommentRepository.findMany).toHaveBeenCalledWith(
@@ -361,7 +362,7 @@ describe('admin.service', () => {
       const result = await service.findReports({
         page: 1,
         pageSize: 10,
-      });
+      }, mockCommentRepository);
 
       expect(result.result).toHaveLength(1);
       expect(mockCommentRepository.findMany).toHaveBeenCalledWith(
@@ -388,7 +389,7 @@ describe('admin.service', () => {
       const result = await service.findReports({
         page: 1,
         pageSize: 10,
-      });
+      }, mockCommentRepository);
 
       expect(result.result).toHaveLength(1);
       expect(mockCommentRepository.findMany).toHaveBeenCalledWith(
@@ -416,7 +417,7 @@ describe('admin.service', () => {
       const result = await service.findReports({
         page: 1,
         pageSize: 10,
-      });
+      }, mockCommentRepository);
 
       expect(result.result).toHaveLength(1);
       const entityCall = mockCommonService.sanitizeCommentEntity.mock.calls.find(
@@ -443,7 +444,7 @@ describe('admin.service', () => {
       const result = await service.findReports({
         page: 1,
         pageSize: 10,
-      });
+      }, mockCommentRepository);
 
       expect(result.result).toHaveLength(1);
       const entityCall = mockCommonService.sanitizeCommentEntity.mock.calls.find(
@@ -470,7 +471,7 @@ describe('admin.service', () => {
       const result = await service.findReports({
         page: 1,
         pageSize: 10,
-      });
+      }, mockCommentRepository);
 
       expect(result.result).toHaveLength(1);
       const entityCall = mockCommonService.sanitizeCommentEntity.mock.calls.find(
@@ -501,7 +502,7 @@ describe('admin.service', () => {
       mockCommonService.findAllInHierarchy.mockResolvedValue([]);
       mockCommonService.sanitizeCommentEntity.mockImplementation((comment) => comment);
 
-      const result = await service.findOneAndThread({ id: 1 });
+      const result = await service.findOneAndThread({ id: 1 }, mockCommentRepository);
 
       expect(result.entity).toBeDefined();
       expect(result.selected).toBeDefined();
@@ -514,7 +515,7 @@ describe('admin.service', () => {
 
       mockCommentRepository.findOne.mockResolvedValue(null);
 
-      await expect(service.findOneAndThread({ id: 1 })).rejects.toThrow('Not found');
+      await expect(service.findOneAndThread({ id: 1 }, mockCommentRepository)).rejects.toThrow('Not found');
     });
 
     it('should throw error when related entity not found', async () => {
@@ -534,7 +535,7 @@ describe('admin.service', () => {
       });
       mockFindOne.mockResolvedValue(null);
 
-      await expect(service.findOneAndThread({ id: 1 })).rejects.toThrow('Relation not found');
+      await expect(service.findOneAndThread({ id: 1 }, mockCommentRepository)).rejects.toThrow('Relation not found');
     });
 
     it('should pass $or filter when removed is true', async () => {
@@ -557,7 +558,7 @@ describe('admin.service', () => {
       mockCommonService.findAllInHierarchy.mockResolvedValue([]);
       mockCommonService.sanitizeCommentEntity.mockImplementation((comment) => comment);
 
-      await service.findOneAndThread({ id: 1, removed: true });
+      await service.findOneAndThread({ id: 1, removed: true }, mockCommentRepository);
 
       expect(mockCommonService.findAllInHierarchy).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -589,7 +590,7 @@ describe('admin.service', () => {
       mockCommonService.findAllInHierarchy.mockResolvedValue([]);
       mockCommonService.sanitizeCommentEntity.mockImplementation((comment) => comment);
 
-      await service.findOneAndThread({ id: 1, removed: false });
+      await service.findOneAndThread({ id: 1, removed: false }, mockCommentRepository);
 
       const filters = mockCommonService.findAllInHierarchy.mock.calls[0][0].filters;
       expect(filters).not.toHaveProperty('$or');
@@ -615,7 +616,7 @@ describe('admin.service', () => {
       mockCommonService.findAllInHierarchy.mockResolvedValue([]);
       mockCommonService.sanitizeCommentEntity.mockImplementation((comment) => comment);
 
-      await service.findOneAndThread({ id: 1 });
+      await service.findOneAndThread({ id: 1 }, mockCommentRepository);
 
       const filters = mockCommonService.findAllInHierarchy.mock.calls[0][0].filters;
       expect(filters).not.toHaveProperty('$or');
@@ -641,7 +642,7 @@ describe('admin.service', () => {
       mockCommonService.findAllInHierarchy.mockResolvedValue([{ id: 2, content: 'Reply' }]);
       mockCommonService.sanitizeCommentEntity.mockImplementation((comment) => comment);
 
-      const result = await service.findOneAndThread({ id: 1 });
+      const result = await service.findOneAndThread({ id: 1 }, mockCommentRepository);
 
       expect(result.entity).toBeDefined();
       expect(result.selected).toBeDefined();
@@ -678,7 +679,7 @@ describe('admin.service', () => {
       mockCommonService.findAllInHierarchy.mockResolvedValue([]);
       mockCommonService.sanitizeCommentEntity.mockImplementation((comment) => comment);
 
-      await service.findOneAndThread({ id: 1 });
+      await service.findOneAndThread({ id: 1 }, mockCommentRepository);
 
       expect(mockCommonService.sanitizeCommentEntity).toHaveBeenCalledWith(
         expect.objectContaining({ id: 1, threadOf: null }),
@@ -709,7 +710,7 @@ describe('admin.service', () => {
       mockCommonService.findAllInHierarchy.mockResolvedValue([]);
       mockCommonService.sanitizeCommentEntity.mockImplementation((comment) => comment);
 
-      await service.findOneAndThread({ id: 1 });
+      await service.findOneAndThread({ id: 1 }, mockCommentRepository);
 
       expect(mockCommonService.sanitizeCommentEntity).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -787,7 +788,7 @@ describe('admin.service', () => {
 
       mockCommonService.approveComment.mockResolvedValue(mockResult);
 
-      const result = await service.approveComment(1);
+      const result = await service.approveComment(1, mockCommentRepository);
 
       expect(result).toEqual(mockResult);
       expect(mockCommonService.approveComment).toHaveBeenCalledWith(1);
@@ -831,7 +832,7 @@ describe('admin.service', () => {
         id: 1,
         content: 'Admin reply',
         author: mockAuthor,
-      });
+      }, mockCommentRepository);
 
       expect(result.isAdminComment).toBe(true);
       expect(result.threadOf).toBe(1);
@@ -849,7 +850,7 @@ describe('admin.service', () => {
           id: 1,
           content: 'Admin reply',
           author: { id: 1, email: 'admin@test.com' },
-        })
+        }, mockCommentRepository)
       ).rejects.toThrow('Not found');
     });
   });
@@ -865,7 +866,7 @@ describe('admin.service', () => {
         removed: true,
       });
 
-      const result = await service.deleteComment(1);
+      const result = await service.deleteComment(1, mockCommentRepository);
 
       expect(result.removed).toBe(true);
       expect(mockCommentRepository.update).toHaveBeenCalledWith({
@@ -891,7 +892,7 @@ describe('admin.service', () => {
         removed: true,
       });
 
-      await service.deleteComment(1);
+      await service.deleteComment(1, mockCommentRepository);
 
       expect(mockReactionsService.removeForComments).toHaveBeenCalledWith(['doc-1'], 'en');
     });
@@ -902,7 +903,7 @@ describe('admin.service', () => {
 
       mockCommentRepository.update.mockResolvedValue(null);
 
-      const result = await service.deleteComment(1);
+      const result = await service.deleteComment(1, mockCommentRepository);
 
       expect(result).toBeNull();
       expect(mockCommentRepository.update).toHaveBeenCalledWith({
@@ -920,7 +921,7 @@ describe('admin.service', () => {
 
       mockCommonService.rejectComment.mockResolvedValue(mockResult);
 
-      const result = await service.rejectComment(1);
+      const result = await service.rejectComment(1, mockCommentRepository);
 
       expect(result).toEqual(mockResult);
       expect(mockCommonService.rejectComment).toHaveBeenCalledWith(1);
@@ -942,7 +943,7 @@ describe('admin.service', () => {
       const result = await service.updateComment({
         id: 1,
         content: 'Updated content',
-      });
+      }, mockCommentRepository);
 
       expect(result.content).toBe('Updated content');
       expect(mockCommentRepository.update).toHaveBeenCalledWith({
@@ -961,7 +962,7 @@ describe('admin.service', () => {
         service.updateComment({
           id: 1,
           content: 'Updated content',
-        })
+        }, mockCommentRepository)
       ).rejects.toThrow('Not found');
     });
   });
@@ -1007,7 +1008,7 @@ describe('admin.service', () => {
 
       mockCommonService.resolveAllAbuseReportsForThread.mockResolvedValue(expected);
 
-      const result = await service.resolveAllAbuseReportsForThread(1);
+      const result = await service.resolveAllAbuseReportsForThread(1, mockCommentRepository);
 
       expect(result).toEqual(expected);
       expect(mockCommonService.resolveAllAbuseReportsForThread).toHaveBeenCalledWith(1);

--- a/server/src/services/__tests__/common.service.test.ts
+++ b/server/src/services/__tests__/common.service.test.ts
@@ -615,13 +615,12 @@ describe('common.service', () => {
         sort: 'createdAt:desc',
       });
 
-      expect(result).toHaveProperty('data');
-      expect(result).toHaveProperty('pagination');
-      const typedData = result.data as CommentWithChildren[];
-      expect(typedData).toHaveLength(1); // One root comment
-      expect(typedData[0].id).toBe(1); // Parent comment
-      expect(typedData[0].children).toHaveLength(2); // Two child comments
-      expect(typedData[0].children![0].children).toHaveLength(1); // One grandchild
+      const typedResult = result as CommentWithChildren[];
+
+      expect(typedResult).toHaveLength(1); // One root comment
+      expect(typedResult[0].id).toBe(1); // Parent comment
+      expect(typedResult[0].children).toHaveLength(2); // Two child comments
+      expect(typedResult[0].children![0].children).toHaveLength(1); // One grandchild
     });
 
     it('should handle empty comments list', async () => {
@@ -640,7 +639,7 @@ describe('common.service', () => {
         fields: ['id', 'content', 'threadOf'],
       });
 
-      expect(result.data).toHaveLength(0);
+      expect(result).toHaveLength(0);
     });
 
     it('should start from specific comment when startingFromId is provided', async () => {
@@ -671,9 +670,10 @@ describe('common.service', () => {
         startingFromId: 2,
       });
 
-      const typedData = result.data as CommentWithChildren[];
-      expect(typedData[0].id).toBe(4);
-      expect(typedData[0].children).toHaveLength(1);
+      const typedResult = result as CommentWithChildren[];
+
+      expect(typedResult[0].id).toBe(4);
+      expect(typedResult[0].children).toHaveLength(1);
     });
 
     it('should handle comments with dropBlockedThreads enabled', async () => {
@@ -709,8 +709,9 @@ describe('common.service', () => {
         dropBlockedThreads: true,
       });
 
-      const typedData = result.data as CommentWithChildren[];
-      expect(typedData[0].children).toHaveLength(0); // drop blocked threads
+      const typedResult = result as CommentWithChildren[];
+
+      expect(typedResult[0].children).toHaveLength(0); // drop blocked threads
     });
 
     it('should return hierarchy without reactions when reactions integration is disabled', async () => {

--- a/server/src/services/__tests__/common.service.test.ts
+++ b/server/src/services/__tests__/common.service.test.ts
@@ -615,12 +615,13 @@ describe('common.service', () => {
         sort: 'createdAt:desc',
       });
 
-      const typedResult = result as CommentWithChildren[];
-
-      expect(typedResult).toHaveLength(1); // One root comment
-      expect(typedResult[0].id).toBe(1); // Parent comment
-      expect(typedResult[0].children).toHaveLength(2); // Two child comments
-      expect(typedResult[0].children![0].children).toHaveLength(1); // One grandchild
+      expect(result).toHaveProperty('data');
+      expect(result).toHaveProperty('pagination');
+      const typedData = result.data as CommentWithChildren[];
+      expect(typedData).toHaveLength(1); // One root comment
+      expect(typedData[0].id).toBe(1); // Parent comment
+      expect(typedData[0].children).toHaveLength(2); // Two child comments
+      expect(typedData[0].children![0].children).toHaveLength(1); // One grandchild
     });
 
     it('should handle empty comments list', async () => {
@@ -639,7 +640,7 @@ describe('common.service', () => {
         fields: ['id', 'content', 'threadOf'],
       });
 
-      expect(result).toHaveLength(0);
+      expect(result.data).toHaveLength(0);
     });
 
     it('should start from specific comment when startingFromId is provided', async () => {
@@ -670,10 +671,9 @@ describe('common.service', () => {
         startingFromId: 2,
       });
 
-      const typedResult = result as CommentWithChildren[];
-
-      expect(typedResult[0].id).toBe(4);
-      expect(typedResult[0].children).toHaveLength(1);
+      const typedData = result.data as CommentWithChildren[];
+      expect(typedData[0].id).toBe(4);
+      expect(typedData[0].children).toHaveLength(1);
     });
 
     it('should handle comments with dropBlockedThreads enabled', async () => {
@@ -709,9 +709,8 @@ describe('common.service', () => {
         dropBlockedThreads: true,
       });
 
-      const typedResult = result as CommentWithChildren[];
-
-      expect(typedResult[0].children).toHaveLength(0); // drop blocked threads
+      const typedData = result.data as CommentWithChildren[];
+      expect(typedData[0].children).toHaveLength(0); // drop blocked threads
     });
 
     it('should return hierarchy without reactions when reactions integration is disabled', async () => {

--- a/server/src/services/admin/admin.service.ts
+++ b/server/src/services/admin/admin.service.ts
@@ -1,5 +1,5 @@
 import { Id, StrapiContext } from '../../@types';
-import { getCommentRepository, getReportCommentRepository } from '../../repositories';
+import { CommentRepository, getCommentRepository, getReportCommentRepository } from '../../repositories';
 import { getDefaultAuthorPopulate } from '../../repositories/utils';
 import { getPluginService } from '../../utils/getPluginService';
 import PluginError from '../../utils/PluginError';
@@ -16,7 +16,7 @@ export default ({ strapi }: StrapiContext) => {
     },
 
     // Find all comments
-    async findAll({ _q, orderBy, page, pageSize, filters }: adminValidator.CommentFindAllSchema) {
+    async findAll({ _q, orderBy, page, pageSize, filters }: adminValidator.CommentFindAllSchema, commentRepository: CommentRepository) {
       const params = utils.findAll.createParams(
         orderBy,
         page,
@@ -26,7 +26,6 @@ export default ({ strapi }: StrapiContext) => {
       );
 
       const populate = utils.findAll.getPopulate();
-      const commentRepository = getCommentRepository(strapi);
       const { pagination, results } = await commentRepository.findWithCount({
         ...params,
         count: true,
@@ -42,7 +41,7 @@ export default ({ strapi }: StrapiContext) => {
       };
     },
 
-    async findReports({ _q, orderBy, page, pageSize }: adminValidator.ReportFindReportsValidator) {
+    async findReports({ _q, orderBy, page, pageSize }: adminValidator.ReportFindReportsValidator, commentRepository: CommentRepository) {
       const params = utils.findReports.createParams(
         orderBy,
         page,
@@ -64,7 +63,7 @@ export default ({ strapi }: StrapiContext) => {
 
       const reportCommentsIds = results.map((entity) => typeof entity.related === 'object' ? entity.related?.id : null).filter(Boolean);
 
-      const commentsThreads = await getCommentRepository(strapi).findMany({
+      const commentsThreads = await commentRepository.findMany({
         where: {
           threadOf: reportCommentsIds,
         },
@@ -106,13 +105,13 @@ export default ({ strapi }: StrapiContext) => {
         pagination,
       };
     },
-    async findOneAndThread({ id, removed, ...query }: adminValidator.FindOneValidatorSchema) {
+    async findOneAndThread({ id, removed, ...query }: adminValidator.FindOneValidatorSchema, commentRepository: CommentRepository) {
       const defaultAuthorUserPopulate = getDefaultAuthorPopulate(strapi);
       const defaultWhere = utils.findOneAndThread.getDefaultWhere(removed);
 
       const defaultPopulate: any = utils.findOneAndThread.getPopulate();
 
-      const entity = await getCommentRepository(strapi).findOne({
+      const entity = await commentRepository.findOne({
         ...defaultPopulate,
         where: { id },
       });
@@ -169,9 +168,9 @@ export default ({ strapi }: StrapiContext) => {
     async changeBlockedComment(id: Id, forceStatus?: boolean) {
       return this.getCommonService().changeBlockedComment(id, forceStatus);
     },
-    async deleteComment(id: Id) {
-      const entity = await getCommentRepository(strapi).findOne({ where: { id } });
-      const removedEntity = await getCommentRepository(strapi).update({
+    async deleteComment(id: Id, commentRepository: CommentRepository) {
+      const entity = await commentRepository.findOne({ where: { id } });
+      const removedEntity = await commentRepository.update({
         where: { id },
         data: { removed: true },
       });
@@ -188,11 +187,11 @@ export default ({ strapi }: StrapiContext) => {
     async blockCommentThread(id: Id, forceStatus?: boolean) {
       return this.getCommonService().changeBlockedCommentThread(id, forceStatus);
     },
-    async approveComment(id: Id) {
-      return this.getCommonService().approveComment(id);
+    async approveComment(id: Id, commentRepository: CommentRepository) {
+      return this.getCommonService().approveComment(id, commentRepository);
     },
-    async rejectComment(id: Id) {
-      return this.getCommonService().rejectComment(id);
+    async rejectComment(id: Id, commentRepository: CommentRepository) {
+      return this.getCommonService().rejectComment(id, commentRepository);
     },
     async resolveAbuseReport({
       id: commentId,
@@ -209,22 +208,22 @@ export default ({ strapi }: StrapiContext) => {
     async resolveAllAbuseReportsForComment(id: Id) {
       return this.getCommonService().resolveAllAbuseReportsForComment(id);
     },
-    async resolveAllAbuseReportsForThread(commentId: number) {
-      return this.getCommonService().resolveAllAbuseReportsForThread(commentId);
+    async resolveAllAbuseReportsForThread(commentId: number, commentRepository: CommentRepository) {
+      return this.getCommonService().resolveAllAbuseReportsForThread(commentId, commentRepository);
     },
     async resolveMultipleAbuseReports({
       reportIds,
     }: adminValidator.ReportsMultipleAbuseValidator) {
       return this.getCommonService().resolveMultipleAbuseReports(reportIds);
     },
-    async postComment({ id, author, content }: adminValidator.CommentPostValidatorSchema) {
-      const entity = await getCommentRepository(strapi).findOne({
+    async postComment({ id, author, content }: adminValidator.CommentPostValidatorSchema, commentRepository: CommentRepository) {
+      const entity = await commentRepository.findOne({
         where: { id },
       });
       if (!entity) {
         throw new PluginError(404, 'Not found');
       }
-      return getCommentRepository(strapi).create({
+      return commentRepository.create({
         data: {
           content: this.getCommonService().sanitizeCommentContent(content),
           threadOf: id,
@@ -236,8 +235,8 @@ export default ({ strapi }: StrapiContext) => {
         },
       });
     },
-    async updateComment({ id, content }: adminValidator.UpdateCommentValidatorSchema) {
-      const entity = await getCommentRepository(strapi).update({
+    async updateComment({ id, content }: adminValidator.UpdateCommentValidatorSchema, commentRepository: CommentRepository) {
+      const entity = await commentRepository.update({
         where: { id },
         data: { content: this.getCommonService().sanitizeCommentContent(content) },
       });

--- a/server/src/services/admin/admin.service.ts
+++ b/server/src/services/admin/admin.service.ts
@@ -16,7 +16,7 @@ export default ({ strapi }: StrapiContext) => {
     },
 
     // Find all comments
-    async findAll({ _q, orderBy, page, pageSize, filters }: adminValidator.CommentFindAllSchema, commentRepository: CommentRepository) {
+    async findAll({ _q, orderBy, page, pageSize, filters }: adminValidator.CommentFindAllSchema, commentRepository: CommentRepository = getCommentRepository(strapi)) {
       const params = utils.findAll.createParams(
         orderBy,
         page,
@@ -41,7 +41,7 @@ export default ({ strapi }: StrapiContext) => {
       };
     },
 
-    async findReports({ _q, orderBy, page, pageSize }: adminValidator.ReportFindReportsValidator, commentRepository: CommentRepository) {
+    async findReports({ _q, orderBy, page, pageSize }: adminValidator.ReportFindReportsValidator, commentRepository: CommentRepository = getCommentRepository(strapi)) {
       const params = utils.findReports.createParams(
         orderBy,
         page,
@@ -105,7 +105,7 @@ export default ({ strapi }: StrapiContext) => {
         pagination,
       };
     },
-    async findOneAndThread({ id, removed, ...query }: adminValidator.FindOneValidatorSchema, commentRepository: CommentRepository) {
+    async findOneAndThread({ id, removed, ...query }: adminValidator.FindOneValidatorSchema, commentRepository: CommentRepository = getCommentRepository(strapi)) {
       const defaultAuthorUserPopulate = getDefaultAuthorPopulate(strapi);
       const defaultWhere = utils.findOneAndThread.getDefaultWhere(removed);
 
@@ -168,7 +168,7 @@ export default ({ strapi }: StrapiContext) => {
     async changeBlockedComment(id: Id, forceStatus?: boolean) {
       return this.getCommonService().changeBlockedComment(id, forceStatus);
     },
-    async deleteComment(id: Id, commentRepository: CommentRepository) {
+    async deleteComment(id: Id, commentRepository: CommentRepository = getCommentRepository(strapi)) {
       const entity = await commentRepository.findOne({ where: { id } });
       const removedEntity = await commentRepository.update({
         where: { id },
@@ -187,11 +187,18 @@ export default ({ strapi }: StrapiContext) => {
     async blockCommentThread(id: Id, forceStatus?: boolean) {
       return this.getCommonService().changeBlockedCommentThread(id, forceStatus);
     },
-    async approveComment(id: Id, commentRepository: CommentRepository) {
+    async approveComment(id: Id, commentRepository = getCommentRepository(strapi)) {
       return this.getCommonService().approveComment(id, commentRepository);
     },
-    async rejectComment(id: Id, commentRepository: CommentRepository) {
+    async rejectComment(id: Id, commentRepository = getCommentRepository(strapi)) {
       return this.getCommonService().rejectComment(id, commentRepository);
+    },
+    async blockNestedThreads(id: Id, status: boolean) {
+      return this.getCommonService().modifiedNestedNestedComments(
+        id,
+        'blockedThread',
+        status,
+      );
     },
     async resolveAbuseReport({
       id: commentId,
@@ -208,7 +215,7 @@ export default ({ strapi }: StrapiContext) => {
     async resolveAllAbuseReportsForComment(id: Id) {
       return this.getCommonService().resolveAllAbuseReportsForComment(id);
     },
-    async resolveAllAbuseReportsForThread(commentId: number, commentRepository: CommentRepository) {
+    async resolveAllAbuseReportsForThread(commentId: number, commentRepository = getCommentRepository(strapi)) {
       return this.getCommonService().resolveAllAbuseReportsForThread(commentId, commentRepository);
     },
     async resolveMultipleAbuseReports({
@@ -216,7 +223,7 @@ export default ({ strapi }: StrapiContext) => {
     }: adminValidator.ReportsMultipleAbuseValidator) {
       return this.getCommonService().resolveMultipleAbuseReports(reportIds);
     },
-    async postComment({ id, author, content }: adminValidator.CommentPostValidatorSchema, commentRepository: CommentRepository) {
+    async postComment({ id, author, content }: adminValidator.CommentPostValidatorSchema, commentRepository: CommentRepository = getCommentRepository(strapi)) {
       return commentRepository.create({
         data: {
           content: this.getCommonService().sanitizeCommentContent(content),
@@ -229,7 +236,7 @@ export default ({ strapi }: StrapiContext) => {
         },
       });
     },
-    async postCommentThread({ id, author, content }: adminValidator.CommentPostValidatorSchema, commentRepository: CommentRepository) {
+    async postCommentThread({ id, author, content }: adminValidator.CommentPostValidatorSchema, commentRepository: CommentRepository = getCommentRepository(strapi)) {
       const entity = await commentRepository.findOne({
         where: { id },
       });
@@ -248,7 +255,7 @@ export default ({ strapi }: StrapiContext) => {
         },
       });
     },
-    async updateComment({ id, content }: adminValidator.UpdateCommentValidatorSchema, commentRepository: CommentRepository) {
+    async updateComment({ id, content }: adminValidator.UpdateCommentValidatorSchema, commentRepository: CommentRepository = getCommentRepository(strapi)) {
       const entity = await commentRepository.update({
         where: { id },
         data: { content: this.getCommonService().sanitizeCommentContent(content) },

--- a/server/src/services/admin/admin.service.ts
+++ b/server/src/services/admin/admin.service.ts
@@ -217,6 +217,19 @@ export default ({ strapi }: StrapiContext) => {
       return this.getCommonService().resolveMultipleAbuseReports(reportIds);
     },
     async postComment({ id, author, content }: adminValidator.CommentPostValidatorSchema, commentRepository: CommentRepository) {
+      return commentRepository.create({
+        data: {
+          content: this.getCommonService().sanitizeCommentContent(content),
+          threadOf: null,
+          authorId: author.id,
+          authorName: getAuthorName(author),
+          authorEmail: author.email,
+          related: id,
+          isAdminComment: true,
+        },
+      });
+    },
+    async postCommentThread({ id, author, content }: adminValidator.CommentPostValidatorSchema, commentRepository: CommentRepository) {
       const entity = await commentRepository.findOne({
         where: { id },
       });

--- a/server/src/services/admin/admin.service.ts
+++ b/server/src/services/admin/admin.service.ts
@@ -193,11 +193,13 @@ export default ({ strapi }: StrapiContext) => {
     async rejectComment(id: Id, commentRepository = getCommentRepository(strapi)) {
       return this.getCommonService().rejectComment(id, commentRepository);
     },
-    async blockNestedThreads(id: Id, status: boolean) {
+    async blockNestedThreads(id: Id, status: boolean, commentRepository: CommentRepository = getCommentRepository(strapi)) {
       return this.getCommonService().modifiedNestedNestedComments(
         id,
         'blockedThread',
         status,
+        undefined,
+        commentRepository,
       );
     },
     async resolveAbuseReport({

--- a/server/src/services/common.service.ts
+++ b/server/src/services/common.service.ts
@@ -7,7 +7,7 @@ import { Id, PathTo, PathValue, RelatedEntity, StrapiContext } from '../@types';
 import { CommentsPluginConfig } from '../config';
 import { APPROVAL_STATUS } from '../const';
 import { ContentTypesUUIDs } from '../content-types';
-import { getCommentRepository, getReportCommentRepository, getStoreRepository } from '../repositories';
+import { CommentRepository, getCommentRepository, getReportCommentRepository, getStoreRepository } from '../repositories';
 import { getOrderBy } from '../repositories/utils';
 import { CONFIG_PARAMS } from '../utils/constants';
 import PluginError from '../utils/PluginError';
@@ -417,8 +417,8 @@ const commonService = ({ strapi }: StrapiContext) => ({
     return this.sanitizeCommentEntity(updatedEntry, []);
   },
 
-  async approveComment(id: Id) {
-    const entity = await getCommentRepository(strapi).update({
+  async approveComment(id: Id, commentRepository: CommentRepository) {
+    const entity = await commentRepository.update({
       where: { id },
       data: { approvalStatus: APPROVAL_STATUS.APPROVED },
     });
@@ -428,8 +428,8 @@ const commonService = ({ strapi }: StrapiContext) => ({
     return this.sanitizeCommentEntity(entity, []);
   },
 
-  async rejectComment(id: Id) {
-    const entity = await getCommentRepository(strapi).update({
+  async rejectComment(id: Id, commentRepository: CommentRepository) {
+    const entity = await commentRepository.update({
       where: { id },
       data: { approvalStatus: APPROVAL_STATUS.REJECTED },
     });
@@ -502,14 +502,14 @@ const commonService = ({ strapi }: StrapiContext) => ({
     });
   },
 
-  async resolveAllAbuseReportsForThread(commentId: number) {
+  async resolveAllAbuseReportsForThread(commentId: number, commentRepository: CommentRepository) {
     if (!commentId) {
       throw new PluginError(
         400,
         'There is something wrong with comment Id. Try again.',
       );
     }
-    const commentsInThread = await getCommentRepository(strapi).findMany({
+    const commentsInThread = await commentRepository.findMany({
       where: {
         threadOf: commentId,
       },

--- a/server/src/services/common.service.ts
+++ b/server/src/services/common.service.ts
@@ -423,7 +423,7 @@ const commonService = ({ strapi }: StrapiContext) => ({
     return this.sanitizeCommentEntity(updatedEntry, []);
   },
 
-  async approveComment(id: Id, commentRepository: CommentRepository) {
+  async approveComment(id: Id, commentRepository = getCommentRepository(strapi)) {
     const entity = await commentRepository.update({
       where: { id },
       data: { approvalStatus: APPROVAL_STATUS.APPROVED },
@@ -434,7 +434,7 @@ const commonService = ({ strapi }: StrapiContext) => ({
     return this.sanitizeCommentEntity(entity, []);
   },
 
-  async rejectComment(id: Id, commentRepository: CommentRepository) {
+  async rejectComment(id: Id, commentRepository = getCommentRepository(strapi)) {
     const entity = await commentRepository.update({
       where: { id },
       data: { approvalStatus: APPROVAL_STATUS.REJECTED },
@@ -508,7 +508,7 @@ const commonService = ({ strapi }: StrapiContext) => ({
     });
   },
 
-  async resolveAllAbuseReportsForThread(commentId: number, commentRepository: CommentRepository) {
+  async resolveAllAbuseReportsForThread(commentId: number, commentRepository = getCommentRepository(strapi)) {
     if (!commentId) {
       throw new PluginError(
         400,

--- a/server/src/services/common.service.ts
+++ b/server/src/services/common.service.ts
@@ -99,7 +99,8 @@ const commonService = ({ strapi }: StrapiContext) => ({
       filters = {},
       locale,
     }: clientValidator.FindAllFlatSchema,
-    relatedEntity?: any
+    relatedEntity?: any,
+    commentRepository: CommentRepository = getCommentRepository(strapi),
   ): Promise<{
     data: Array<CommentWithRelated | Comment>;
     pagination?: Pagination;
@@ -137,15 +138,12 @@ const commonService = ({ strapi }: StrapiContext) => ({
       page: pagination?.page || (skip ? Math.floor(skip / limit) : 1) || 1,
     };
 
-    const { results: entries, pagination: resultPaginationData } =
-      await getCommentRepository(strapi).findWithCount(params);
+    const { results: entries, pagination: resultPaginationData } = await commentRepository.findWithCount(params);
 
     const entriesWithThreads = await Promise.all(
       entries.map(async (_) => {
-        const {
-          results,
-          pagination: { total },
-        } = await getCommentRepository(strapi).findWithCount({
+        const { results, pagination: { total } } = await commentRepository
+        .findWithCount({
           where: {
             threadOf: _.id,
           },
@@ -241,7 +239,8 @@ const commonService = ({ strapi }: StrapiContext) => ({
     entry: Comment | CommentWithRelated,
     relatedEntity?: any,
     dropBlockedThreads = false,
-    blockNestedThreads = false
+    blockNestedThreads = false,
+    commentRepository: CommentRepository = getCommentRepository(strapi),
   ) {
     if (!entry.gotThread) {
       return {
@@ -267,30 +266,33 @@ const commonService = ({ strapi }: StrapiContext) => ({
         locale,
         limit: Number.MAX_SAFE_INTEGER,
       },
-      relatedEntity
+      relatedEntity,
+      commentRepository,
     );
     const allChildren =
       entry.blockedThread && dropBlockedThreads
         ? []
         : await Promise.all(
-          children.data.map((child) =>
-            this.getCommentsChildren(
-              {
-                filters,
-                populate,
-                sort,
-                fields,
-                isAdmin,
-                omit,
-                locale,
-                limit,
-              },
-              child,
-              relatedEntity,
-              dropBlockedThreads
-            )
-          )
-        );
+            children.data.map((child) =>
+              this.getCommentsChildren(
+                {
+                  filters,
+                  populate,
+                  sort,
+                  fields,
+                  isAdmin,
+                  omit,
+                  locale,
+                  limit,
+                },
+                child,
+                relatedEntity,
+                dropBlockedThreads,
+                undefined,
+                commentRepository,
+              ),
+            ),
+          );
 
     return {
       ...entry,
@@ -316,7 +318,8 @@ const commonService = ({ strapi }: StrapiContext) => ({
       limit,
       pagination,
     }: clientValidator.FindAllInHierarchyValidatorSchema,
-    relatedEntity?: any
+    relatedEntity?: any,
+    commentRepository: CommentRepository = getCommentRepository(strapi),
   ) {
     const rootEntries = await this.findAllFlat(
       {
@@ -333,7 +336,8 @@ const commonService = ({ strapi }: StrapiContext) => ({
         locale,
         limit,
       },
-      relatedEntity
+      relatedEntity,
+      commentRepository,
     );
 
     const rootEntriesWithChildren = await Promise.all(
@@ -351,9 +355,11 @@ const commonService = ({ strapi }: StrapiContext) => ({
           },
           entry,
           relatedEntity,
-          dropBlockedThreads
-        )
-      )
+          dropBlockedThreads,
+          undefined,
+          commentRepository,
+        ),
+      ),
     );
 
     const reactionsService = getPluginService(strapi, 'reactions');
@@ -371,8 +377,8 @@ const commonService = ({ strapi }: StrapiContext) => ({
   },
 
   // Find single comment
-  async findOne(criteria: Partial<Params['where']>) {
-    const entity = await getCommentRepository(strapi).findOne({
+  async findOne(criteria: Partial<Params['where']>, commentRepository: CommentRepository = getCommentRepository(strapi)) {
+    const entity = await commentRepository.findOne({
       where: criteria,
       populate: {
         reports: true,
@@ -390,12 +396,12 @@ const commonService = ({ strapi }: StrapiContext) => ({
     return filterOurResolvedReports(item);
   },
 
-  async findMany(criteria: Params) {
-    return getCommentRepository(strapi).findMany(criteria);
+  async findMany(criteria: Params, commentRepository: CommentRepository = getCommentRepository(strapi)) {
+    return commentRepository.findMany(criteria);
   },
 
-  async updateComment(criteria: Partial<Params['where']>, data: Partial<Comment>) {
-    return getCommentRepository(strapi).update({ where: criteria, data });
+  async updateComment(criteria: Partial<Params['where']>, data: Partial<Comment>, commentRepository: CommentRepository = getCommentRepository(strapi)) {
+    return commentRepository.update({ where: criteria, data });
   },
 
   async changeBlockedComment(id: Id, forceStatus?: boolean) {
@@ -656,26 +662,20 @@ const commonService = ({ strapi }: StrapiContext) => ({
     };
   },
   // TODO: we need to add deepLimit to the function to prevent infinite loops
-  async modifiedNestedNestedComments<T extends keyof Comment>(
-    id: Id,
-    fieldName: T,
-    value: Comment[T],
-    deepLimit: number = 10
-  ): Promise<boolean> {
+  async modifiedNestedNestedComments<T extends keyof Comment>(id: Id, fieldName: T, value: Comment[T], deepLimit: number = 10, commentRepository: CommentRepository = getCommentRepository(strapi)): Promise<boolean> {
     if (deepLimit === 0) {
       return true;
     }
     try {
-      const entities = await this.findMany({ where: { threadOf: id } });
-      const changedEntries = await getCommentRepository(strapi).updateMany({
+      const entities = await this.findMany({ where: { threadOf: id } }, commentRepository);
+      const changedEntries = await commentRepository.updateMany({
         where: { id: entities.map((entity) => entity.id) },
         data: { [fieldName]: value },
       });
       if (entities.length === changedEntries.count && changedEntries.count > 0) {
         const nestedTransactions = await Promise.all(
           entities.map((item) =>
-            this.modifiedNestedNestedComments(item.id, fieldName, value, deepLimit - 1)
-          )
+            this.modifiedNestedNestedComments(item.id, fieldName, value, deepLimit - 1, commentRepository)),
         );
         return nestedTransactions.length === changedEntries.count;
       }
@@ -700,10 +700,10 @@ const commonService = ({ strapi }: StrapiContext) => ({
     return content;
   },
 
-  async perRemove(related: string, locale?: string) {
-    const defaultLocale =
-      (await strapi.plugin('i18n')?.service('locales').getDefaultLocale()) || null;
-    return getCommentRepository(strapi).updateMany({
+  async perRemove(related: string, locale?: string, commentRepository: CommentRepository = getCommentRepository(strapi)) {
+    const defaultLocale = await strapi.plugin('i18n')?.service('locales').getDefaultLocale() || null;
+    return commentRepository
+    .updateMany({
       where: {
         related,
         $or: [{ locale }, defaultLocale === locale ? { locale: { $eq: null } } : null].filter(


### PR DESCRIPTION
## Summary

- Inject `CommentRepository` as an optional last argument on admin and common comment services (defaulting to `getCommentRepository(strapi)`), so callers can swap the repository without changing service internals.
- Split admin posting into two methods: `postComment` creates a top-level admin comment (`threadOf: null`, `related` is the content relation), and `postCommentThread` replies in an existing thread. The existing route `POST /moderate/thread/:id/postComment` now calls `postCommentThread`, so the HTTP path for thread replies is unchanged.
- Expose `blockNestedThreads` on the admin service as a wrapper around `modifiedNestedNestedComments`.
- Update admin/common service tests to pass a mock repository and cover the new post/thread split.

## Test plan

- [ ] Admin list, reports, thread details, approve, reject, update, and delete still work with the default repository (no injected repo).
- [ ] Posting a moderator reply via `POST /moderate/thread/:id/postComment` still creates a child comment (`threadOf` = that id), not a top-level comment.
- [ ] `postComment` (service) creates a top-level admin comment on the related entity.
- [ ] Blocking a nested thread via `blockNestedThreads` updates descendant `blockedThread` flags.
- [ ] Unit tests: `admin.service`, `common.service`, `admin.controller`.
- [ ] Confirm `findAllInHierarchy` response shape: the “pagination on comments tree” commit only changed tests to expect `{ data, pagination }`, but the service still returns an array. Either restore the old assertions or wrap the tree in `{ data, pagination }` before merge.
